### PR TITLE
Support LLVM 15

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,3 +1,12 @@
 {
-  "words": ["femtomc", "libdir", "melior", "mlir", "rustc", "stdc"]
+  "words": [
+    "addf",
+    "femtomc",
+    "libdir",
+    "melior",
+    "memref",
+    "mlir",
+    "rustc",
+    "stdc"
+  ]
 }

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,4 +26,4 @@ jobs:
       - run: curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s 15 all
       - run: sudo apt -y install libmlir-15-dev mlir-15-tools
       # - run: tools/setup.sh
-      - run: cargo test
+      - run: PATH=/usr/lib/llvm-15/bin:$PATH cargo test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - run: curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s 15 all
       # TODO Support macOS with LLVM 15.
+      - run: curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s 15 all
+      - run: sudo apt -y install libmlir-15-dev mlir-15-tools
       # - run: tools/setup.sh
       - run: cargo test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,4 +23,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: tools/setup.sh
-      - run: PATH=/usr/lib/llvm-15/bin:$PATH cargo test
+      - run: cargo test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,9 +17,12 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macos-12
+          # TODO Support macOS with LLVM 15.
+          # - macos-12
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - run: tools/setup.sh
+      - run: curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s 15 all
+      # TODO Support macOS with LLVM 15.
+      # - run: tools/setup.sh
       - run: cargo test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,8 +22,5 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      # TODO Support macOS with LLVM 15.
-      - run: curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s 15 all
-      - run: sudo apt -y install libmlir-15-dev mlir-15-tools
-      # - run: tools/setup.sh
+      - run: tools/setup.sh
       - run: PATH=/usr/lib/llvm-15/bin:$PATH cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ name = "melior"
 version = "0.1.0"
 dependencies = [
  "mlir-sys",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
@@ -74,9 +74,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6b561dcf059c85bbe388e0a7b0a1469acb3934cc0cfa148613a830629e3049"
+checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
 dependencies = [
  "glob",
  "libc",
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.8"
+version = "3.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
+checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
 dependencies = [
  "atty",
  "bitflags",
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "env_logger"
@@ -134,9 +134,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
@@ -177,9 +177,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libloading"
@@ -221,8 +221,8 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mlir-sys"
-version = "0.1.0"
-source = "git+https://github.com/raviqqe/mlir-sys?branch=chore/llvm-15#4580e7505eb391bf8bf1f4a9bbc76cb11ff7439f"
+version = "0.1.2"
+source = "git+https://github.com/raviqqe/mlir-sys?branch=chore/llvm-15#24d67ad7ea5241e3502f38bf7e317a982a176d41"
 dependencies = [
  "bindgen",
 ]
@@ -238,10 +238,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.1.0"
+name = "once_cell"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "peeking_take_while"
@@ -251,27 +257,27 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -280,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rustc-hash"
@@ -319,19 +325,19 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "which"
-version = "4.2.5"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
 dependencies = [
  "either",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,9 +221,8 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mlir-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862008e37bf6d24638aa27f929441d015f57c900acc1966557d626fb4a71d0da"
+version = "0.1.0"
+source = "git+https://github.com/raviqqe/mlir-sys?branch=chore/llvm-15#4580e7505eb391bf8bf1f4a9bbc76cb11ff7439f"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mlir-sys"
 version = "0.1.2"
-source = "git+https://github.com/raviqqe/mlir-sys#bcb8096504864c34f4c8b944a4319b2587bf835f"
+source = "git+https://github.com/raviqqe/mlir-sys#d8ea2f99f0ae0f461fa9f51a41bc1e1daf3e07b4"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mlir-sys"
 version = "0.1.2"
-source = "git+https://github.com/raviqqe/mlir-sys?branch=chore/llvm-15#24d67ad7ea5241e3502f38bf7e317a982a176d41"
+source = "git+https://github.com/raviqqe/mlir-sys#bcb8096504864c34f4c8b944a4319b2587bf835f"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ license-file = "LICENSE"
 repository = "https://github.com/raviqqe/melior"
 
 [dependencies]
-mlir-sys = "0.1"
+mlir-sys = { git = "https://github.com/raviqqe/mlir-sys", branch = "chore/llvm-15" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ license-file = "LICENSE"
 repository = "https://github.com/raviqqe/melior"
 
 [dependencies]
-mlir-sys = { git = "https://github.com/raviqqe/mlir-sys", branch = "chore/llvm-15" }
+mlir-sys = { git = "https://github.com/raviqqe/mlir-sys" }
 once_cell = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ repository = "https://github.com/raviqqe/melior"
 
 [dependencies]
 mlir-sys = { git = "https://github.com/raviqqe/mlir-sys", branch = "chore/llvm-15" }
+once_cell = "1"

--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2021 Yota Toyama
+   Copyright 2022 Yota Toyama, LLVM Team
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ Melior is still in the alpha stage as well as the MLIR C API. Contribution is we
 
 ### Naming conventions
 
+- `mlir<X>Create*` functions are renamed as `<X>::new`.
 - `mlir<X>Get<Y>` functions are renamed as follows:
-  - If the resulting objects refer to `self`, they are named `<X>::as_<Y>()`.
-  - Otherwise, they are named just `<X>::<Y>()` and may have argments, such as position indices.
+  - If the resulting objects refer to `self`, they are named `<X>::as_<Y>`.
+  - Otherwise, they are named just `<X>::<Y>` and may have argments, such as position indices.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Melior is still in the alpha stage as well as the MLIR C API. Contribution is we
 
 - `mlir<X>Create*` functions are renamed as `<X>::new`.
 - `mlir<X>Get<Y>` functions are renamed as follows:
-  - If the resulting objects refer to `self`, they are named `<X>::as_<Y>`.
+  - If the resulting objects refer to `&self`, they are named `<X>::as_<Y>`.
   - Otherwise, they are named just `<X>::<Y>` and may have argments, such as position indices.
 
 ## References

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This crate is a wrapper of [the MLIR C API](https://mlir.llvm.org/docs/CAPI/).
 
 ## Contribution
 
-Melior is still the alpha stage as well as the MLIR C API. Contribution is welcome! But, note that the API is unstable and can have breaking changes in the future.
+Melior is still in the alpha stage as well as the MLIR C API. Contribution is welcome! But, note that the API is unstable and can have breaking changes in the future.
 
 ### Naming conventions
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ This crate is a wrapper of [the MLIR C API](https://mlir.llvm.org/docs/CAPI/).
 
 ## Dependencies
 
-- LLVM/MLIR 14
+- LLVM/MLIR 15
 
 ## References
 
-- [TheDan64/inkwell](https://github.com/TheDan64/inkwell)
+- The raw C binding generation depends on [femtomc/mlir-sys](https://github.com/femtomc/mlir-sys).
+- The overall design is inspired by [TheDan64/inkwell](https://github.com/TheDan64/inkwell).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ This crate is a wrapper of [the MLIR C API](https://mlir.llvm.org/docs/CAPI/).
 
 - LLVM/MLIR 15
 
+## Contribution
+
+Melior is still the alpha stage as well as the MLIR C API. Contribution is welcome! But, note that the API is unstable and can have breaking changes in the future.
+
+### Naming conventions
+
+- `mlir<X>Get<Y>` functions are renamed as follows:
+  - If the resulting objects refer to `self`, they are named `<X>::as_<Y>()`.
+  - Otherwise, they are named just `<X>::<Y>()` and may have argments, such as position indices.
+
 ## References
 
 - The raw C binding generation depends on [femtomc/mlir-sys](https://github.com/femtomc/mlir-sys).

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -5,6 +5,7 @@ use crate::{
 use mlir_sys::{mlirAttributeGetContext, mlirAttributeParseGet, MlirAttribute};
 use std::marker::PhantomData;
 
+// Attributes are always values but their internal storage is owned by contexts.
 pub struct Attribute<'c> {
     attribute: MlirAttribute,
     _context: PhantomData<&'c Context>,

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -1,6 +1,6 @@
 use crate::{
     context::{Context, ContextRef},
-    utility::as_string_ref,
+    string_ref::StringRef,
 };
 use mlir_sys::{mlirAttributeGetContext, mlirAttributeParseGet, MlirAttribute};
 use std::marker::PhantomData;
@@ -14,7 +14,9 @@ pub struct Attribute<'c> {
 impl<'c> Attribute<'c> {
     pub fn parse(context: &Context, source: &str) -> Self {
         Self {
-            attribute: unsafe { mlirAttributeParseGet(context.to_raw(), as_string_ref(source)) },
+            attribute: unsafe {
+                mlirAttributeParseGet(context.to_raw(), StringRef::from(source).to_raw())
+            },
             _context: Default::default(),
         }
     }

--- a/src/block.rs
+++ b/src/block.rs
@@ -63,14 +63,14 @@ impl<'c> Drop for Block<'c> {
 // TODO Should we split context lifetimes? Or, is it transitively proven that 'c > 'a?
 pub struct BlockRef<'a> {
     block: ManuallyDrop<Block<'a>>,
-    _block: PhantomData<&'a Block<'a>>,
+    _reference: PhantomData<&'a Block<'a>>,
 }
 
 impl<'a> BlockRef<'a> {
     pub(crate) unsafe fn from_raw(block: MlirBlock) -> Self {
         Self {
             block: ManuallyDrop::new(Block::from_raw(block)),
-            _block: Default::default(),
+            _reference: Default::default(),
         }
     }
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -66,15 +66,6 @@ pub struct BlockRef<'a> {
     _reference: PhantomData<&'a Block<'a>>,
 }
 
-impl<'a> BlockRef<'a> {
-    pub(crate) unsafe fn from_raw(block: MlirBlock) -> Self {
-        Self {
-            block: ManuallyDrop::new(Block::from_raw(block)),
-            _reference: Default::default(),
-        }
-    }
-}
-
 impl<'a> Deref for BlockRef<'a> {
     type Target = Block<'a>;
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,7 +1,7 @@
 use crate::{
     context::Context, location::Location, r#type::Type, region::RegionRef, utility::into_raw_array,
 };
-use mlir_sys::{mlirBlockCreate, mlirBlockGetParentRegion, MlirBlock};
+use mlir_sys::{mlirBlockCreate, mlirBlockDestroy, mlirBlockGetParentRegion, MlirBlock};
 use std::marker::PhantomData;
 
 pub struct Block<'c> {

--- a/src/block.rs
+++ b/src/block.rs
@@ -63,14 +63,26 @@ impl<'c> Block<'c> {
         }
     }
 
-    pub fn insert_operation(&mut self, position: usize, operation: Operation) {
+    // TODO How can we make those update functions take `&mut self`?
+    // TODO Use cells?
+    pub fn insert_operation(&self, position: usize, operation: Operation) -> OperationRef {
         unsafe {
-            mlirBlockInsertOwnedOperation(self.block, position as isize, operation.into_raw())
+            let operation = operation.into_raw();
+
+            mlirBlockInsertOwnedOperation(self.block, position as isize, operation);
+
+            OperationRef::from_raw(operation)
         }
     }
 
-    pub fn append_operation(&mut self, operation: Operation) {
-        unsafe { mlirBlockAppendOwnedOperation(self.block, operation.into_raw()) }
+    pub fn append_operation(&self, operation: Operation) -> OperationRef {
+        unsafe {
+            let operation = operation.into_raw();
+
+            mlirBlockAppendOwnedOperation(self.block, operation);
+
+            OperationRef::from_raw(operation)
+        }
     }
 
     pub(crate) unsafe fn from_raw(block: MlirBlock) -> Self {

--- a/src/block.rs
+++ b/src/block.rs
@@ -8,8 +8,9 @@ use crate::{
     value::Value,
 };
 use mlir_sys::{
-    mlirBlockAppendOwnedOperation, mlirBlockCreate, mlirBlockDestroy, mlirBlockGetArgument,
-    mlirBlockGetFirstOperation, mlirBlockGetParentRegion, mlirBlockInsertOwnedOperation, MlirBlock,
+    mlirBlockAddArgument, mlirBlockAppendOwnedOperation, mlirBlockCreate, mlirBlockDestroy,
+    mlirBlockGetArgument, mlirBlockGetFirstOperation, mlirBlockGetParentRegion,
+    mlirBlockInsertOwnedOperation, MlirBlock,
 };
 use std::{
     marker::PhantomData,
@@ -60,6 +61,16 @@ impl<'c> Block<'c> {
             } else {
                 Some(OperationRef::from_raw(operation))
             }
+        }
+    }
+
+    pub fn add_argument(&self, r#type: Type<'c>, location: Location<'c>) -> Value {
+        unsafe {
+            Value::from_raw(mlirBlockAddArgument(
+                self.block,
+                r#type.to_raw(),
+                location.to_raw(),
+            ))
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,7 +1,8 @@
-use crate::dialect_registry::DialectRegistry;
+use crate::{dialect::Dialect, dialect_registry::DialectRegistry, string_ref::StringRef};
 use mlir_sys::{
     mlirContextAppendDialectRegistry, mlirContextCreate, mlirContextDestroy,
-    mlirContextLoadAllAvailableDialects, mlirRegisterAllLLVMTranslations, MlirContext,
+    mlirContextGetOrLoadDialect, mlirContextLoadAllAvailableDialects,
+    mlirRegisterAllLLVMTranslations, MlirContext,
 };
 use std::{marker::PhantomData, mem::ManuallyDrop, ops::Deref};
 
@@ -16,6 +17,15 @@ impl Context {
         unsafe { mlirRegisterAllLLVMTranslations(context) }
 
         Self { context }
+    }
+
+    pub fn get_or_load_dialect(&self, name: &str) -> Dialect {
+        unsafe {
+            Dialect::from_raw(mlirContextGetOrLoadDialect(
+                self.context,
+                StringRef::from(name).to_raw(),
+            ))
+        }
     }
 
     pub fn append_dialect_registry(&self, registry: &DialectRegistry) {

--- a/src/context.rs
+++ b/src/context.rs
@@ -55,14 +55,14 @@ impl Default for Context {
 
 pub struct ContextRef<'c> {
     context: ManuallyDrop<Context>,
-    _context: PhantomData<&'c Context>,
+    _reference: PhantomData<&'c Context>,
 }
 
 impl<'c> ContextRef<'c> {
     pub(crate) unsafe fn from_raw(context: MlirContext) -> Self {
         Self {
             context: ManuallyDrop::new(Context { context }),
-            _context: Default::default(),
+            _reference: Default::default(),
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,7 @@
-use mlir_sys::{mlirContextCreate, mlirContextDestroy, MlirContext};
+use crate::dialect_registry::DialectRegistry;
+use mlir_sys::{
+    mlirContextAppendDialectRegistry, mlirContextCreate, mlirContextDestroy, MlirContext,
+};
 use std::{marker::PhantomData, mem::ManuallyDrop, ops::Deref};
 
 pub struct Context {
@@ -10,6 +13,10 @@ impl Context {
         Self {
             context: unsafe { mlirContextCreate() },
         }
+    }
+
+    pub fn append_dialect_registry(&self, registry: &DialectRegistry) {
+        unsafe { mlirContextAppendDialectRegistry(self.to_raw(), registry.to_raw()) }
     }
 
     pub(crate) unsafe fn to_raw(&self) -> MlirContext {
@@ -58,5 +65,12 @@ mod tests {
     #[test]
     fn new() {
         Context::new();
+    }
+
+    #[test]
+    fn append_dialect_registry() {
+        let context = Context::new();
+
+        context.append_dialect_registry(&DialectRegistry::new());
     }
 }

--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -1,0 +1,21 @@
+use crate::context::{Context, ContextRef};
+use mlir_sys::{mlirDialectGetContext, MlirDialect};
+use std::marker::PhantomData;
+
+pub struct Dialect<'c> {
+    dialect: MlirDialect,
+    _context: PhantomData<&'c Context>,
+}
+
+impl<'c> Dialect<'c> {
+    pub fn context(&self) -> ContextRef<'c> {
+        unsafe { ContextRef::from_raw(mlirDialectGetContext(self.dialect)) }
+    }
+
+    pub(crate) unsafe fn from_raw(dialect: MlirDialect) -> Self {
+        Self {
+            dialect,
+            _context: Default::default(),
+        }
+    }
+}

--- a/src/dialect_registry.rs
+++ b/src/dialect_registry.rs
@@ -2,7 +2,6 @@ use mlir_sys::{
     mlirDialectRegistryCreate, mlirDialectRegistryDestroy, mlirRegisterAllDialects,
     MlirDialectRegistry,
 };
-use std::{marker::PhantomData, mem::ManuallyDrop, ops::Deref};
 
 pub struct DialectRegistry {
     registry: MlirDialectRegistry,
@@ -33,28 +32,6 @@ impl Drop for DialectRegistry {
 impl Default for DialectRegistry {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-pub struct DialectRegistryRef<'r> {
-    registry: ManuallyDrop<DialectRegistry>,
-    _registry: PhantomData<&'r DialectRegistry>,
-}
-
-impl<'r> DialectRegistryRef<'r> {
-    pub(crate) unsafe fn from_raw(registry: MlirDialectRegistry) -> Self {
-        Self {
-            registry: ManuallyDrop::new(DialectRegistry { registry }),
-            _registry: Default::default(),
-        }
-    }
-}
-
-impl<'c> Deref for DialectRegistryRef<'c> {
-    type Target = DialectRegistry;
-
-    fn deref(&self) -> &Self::Target {
-        &self.registry
     }
 }
 

--- a/src/dialect_registry.rs
+++ b/src/dialect_registry.rs
@@ -1,0 +1,74 @@
+use mlir_sys::{
+    mlirDialectRegistryCreate, mlirDialectRegistryDestroy, mlirRegisterAllDialects,
+    MlirDialectRegistry,
+};
+use std::{marker::PhantomData, mem::ManuallyDrop, ops::Deref};
+
+pub struct DialectRegistry {
+    registry: MlirDialectRegistry,
+}
+
+impl DialectRegistry {
+    pub fn new() -> Self {
+        Self {
+            registry: unsafe { mlirDialectRegistryCreate() },
+        }
+    }
+
+    pub fn register_all_dialects(&self) {
+        unsafe { mlirRegisterAllDialects(self.to_raw()) }
+    }
+
+    pub(crate) unsafe fn to_raw(&self) -> MlirDialectRegistry {
+        self.registry
+    }
+}
+
+impl Drop for DialectRegistry {
+    fn drop(&mut self) {
+        unsafe { mlirDialectRegistryDestroy(self.registry) };
+    }
+}
+
+impl Default for DialectRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct DialectRegistryRef<'r> {
+    registry: ManuallyDrop<DialectRegistry>,
+    _registry: PhantomData<&'r DialectRegistry>,
+}
+
+impl<'r> DialectRegistryRef<'r> {
+    pub(crate) unsafe fn from_raw(registry: MlirDialectRegistry) -> Self {
+        Self {
+            registry: ManuallyDrop::new(DialectRegistry { registry }),
+            _registry: Default::default(),
+        }
+    }
+}
+
+impl<'c> Deref for DialectRegistryRef<'c> {
+    type Target = DialectRegistry;
+
+    fn deref(&self) -> &Self::Target {
+        &self.registry
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new() {
+        DialectRegistry::new();
+    }
+
+    #[test]
+    fn register_all_dialects() {
+        DialectRegistry::new();
+    }
+}

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -1,6 +1,6 @@
 use crate::{
     context::{Context, ContextRef},
-    utility::as_string_ref,
+    string_ref::StringRef,
 };
 use mlir_sys::{mlirIdentifierGet, mlirIdentifierGetContext, MlirIdentifier};
 use std::marker::PhantomData;
@@ -13,7 +13,9 @@ pub struct Identifier<'c> {
 impl<'c> Identifier<'c> {
     pub fn new(context: &Context, name: &str) -> Self {
         Self {
-            identifier: unsafe { mlirIdentifierGet(context.to_raw(), as_string_ref(name)) },
+            identifier: unsafe {
+                mlirIdentifierGet(context.to_raw(), StringRef::from(name).to_raw())
+            },
             _context: Default::default(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,9 @@ pub mod value;
 #[cfg(test)]
 mod tests {
     use crate::{
-        context::Context, dialect_registry::DialectRegistry, location::Location, module::Module,
+        attribute::Attribute, block::Block, context::Context, dialect_registry::DialectRegistry,
+        identifier::Identifier, location::Location, module::Module, operation::Operation,
+        operation_state::OperationState, r#type::Type, region::Region,
     };
 
     #[test]
@@ -34,6 +36,79 @@ mod tests {
         let context = Context::new();
         context.append_dialect_registry(&registry);
         let module = Module::new(Location::unknown(&context));
+
+        assert_eq!(module.as_operation().print().as_str().to_str().unwrap(), "");
+    }
+
+    #[test]
+    fn build_add() {
+        let registry = DialectRegistry::new();
+        registry.register_all_dialects();
+
+        let context = Context::new();
+        context.append_dialect_registry(&registry);
+        context.get_or_load_dialect("func");
+        context.get_or_load_dialect("memref");
+        context.get_or_load_dialect("shape");
+        context.get_or_load_dialect("scf");
+
+        let module = Module::new(Location::unknown(&context));
+
+        let r#type = Type::parse(&context, "memref<?xf32>");
+
+        let function = {
+            let region = Region::new();
+            let block = Block::new(vec![
+                (r#type, Location::unknown(&context)),
+                (r#type, Location::unknown(&context)),
+            ]);
+
+            block.append_operation({
+                let mut state = OperationState::new("arith.constant", Location::unknown(&context));
+
+                state.add_results(vec![Type::parse(&context, "index")]);
+                state.add_attributes(vec![(
+                    Identifier::new(&context, "value"),
+                    Attribute::parse(&context, "0 : index"),
+                )]);
+
+                Operation::new(state)
+            });
+
+            // TODO
+
+            block.append_operation(Operation::new(OperationState::new(
+                "func.return",
+                Location::unknown(&context),
+            )));
+
+            region.append_block(block);
+
+            let mut state = OperationState::new("func.func", Location::unknown(&context));
+
+            state.add_attributes(vec![
+                (
+                    Identifier::new(&context, "function_type"),
+                    Attribute::parse(&context, "(memref<?xf32>, memref<?xf32>) -> ()"),
+                ),
+                (
+                    Identifier::new(&context, "sym_name"),
+                    Attribute::parse(&context, "\"add\""),
+                ),
+            ]);
+            state.add_regions(vec![region]);
+
+            Operation::new(state)
+        };
+
+        module
+            .as_operation()
+            .region(0)
+            .first_block()
+            .insert_operation(0, function);
+
+        module.as_operation().dump();
+        assert!(module.as_operation().verify());
 
         assert_eq!(module.as_operation().print().as_str().to_str().unwrap(), "");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,13 +55,13 @@ mod tests {
         context.get_or_load_dialect("scf");
 
         let location = Location::unknown(&context);
-        let module = Module::new(location);
+        let mut module = Module::new(location);
 
         let r#type = Type::parse(&context, "memref<?xf32>");
 
         let function = {
             let region = Region::new();
-            let block = Block::new(vec![(r#type, location), (r#type, location)]);
+            let mut block = Block::new(vec![(r#type, location), (r#type, location)]);
             let index_type = Type::parse(&context, "index");
 
             block.append_operation({
@@ -114,11 +114,7 @@ mod tests {
             Operation::new(state)
         };
 
-        module
-            .as_operation()
-            .region(0)
-            .first_block()
-            .insert_operation(0, function);
+        module.body_mut().insert_operation(0, function);
 
         module.as_operation().dump();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod module;
 pub mod operation;
 pub mod operation_state;
 pub mod region;
+pub mod string_ref;
 pub mod r#type;
 pub mod utility;
 pub mod value;
@@ -22,6 +23,8 @@ mod tests {
     fn build_module() {
         let context = Context::new();
         let module = Module::new(Location::unknown(&context));
+
+        assert_eq!(module.as_operation().print().as_str(), "\0");
     }
 
     #[test]
@@ -30,5 +33,7 @@ mod tests {
         let context = Context::new();
         context.append_dialect_registry(&registry);
         let module = Module::new(Location::unknown(&context));
+
+        assert_eq!(module.as_operation().print().as_str(), "\0");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ mod tests {
         let context = Context::new();
         let module = Module::new(Location::unknown(&context));
 
-        assert_eq!(module.as_operation().print().as_str().to_str().unwrap(), "");
+        assert_eq!(module.as_operation().print(), "module{}");
     }
 
     #[test]
@@ -37,7 +37,7 @@ mod tests {
         context.append_dialect_registry(&registry);
         let module = Module::new(Location::unknown(&context));
 
-        assert_eq!(module.as_operation().print().as_str().to_str().unwrap(), "");
+        assert_eq!(module.as_operation().print(), "module{}");
     }
 
     #[test]
@@ -108,8 +108,8 @@ mod tests {
             .insert_operation(0, function);
 
         module.as_operation().dump();
-        assert!(module.as_operation().verify());
 
-        assert_eq!(module.as_operation().print().as_str().to_str().unwrap(), "");
+        assert!(module.as_operation().verify());
+        assert_eq!(module.as_operation().print(), "");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod tests {
         let context = Context::new();
         let module = Module::new(Location::unknown(&context));
 
+        assert!(module.as_operation().verify());
         assert_eq!(module.as_operation().print(), "module{}");
     }
 
@@ -37,6 +38,7 @@ mod tests {
         context.append_dialect_registry(&registry);
         let module = Module::new(Location::unknown(&context));
 
+        assert!(module.as_operation().verify());
         assert_eq!(module.as_operation().print(), "module{}");
     }
 
@@ -110,6 +112,7 @@ mod tests {
         module.as_operation().dump();
 
         assert!(module.as_operation().verify());
-        assert_eq!(module.as_operation().print(), "");
+        // TODO Fix this. Somehow, MLIR inserts null characters in the middle of string refs.
+        // assert_eq!(module.as_operation().print(), "");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,8 +185,6 @@ mod tests {
 
         module.body_mut().insert_operation(0, function);
 
-        module.as_operation().dump();
-
         assert!(module.as_operation().verify());
         // TODO Fix this. Somehow, MLIR inserts null characters in the middle of string refs.
         // assert_eq!(module.as_operation().print(), "");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod attribute;
 pub mod block;
 pub mod context;
+pub mod dialect;
 pub mod dialect_registry;
 pub mod identifier;
 pub mod location;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod attribute;
 pub mod block;
 pub mod context;
+pub mod dialect_registry;
 pub mod identifier;
 pub mod location;
 pub mod module;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ mod tests {
         let context = Context::new();
         let module = Module::new(Location::unknown(&context));
 
-        assert_eq!(module.as_operation().print().as_str(), "\0");
+        assert_eq!(module.as_operation().print().as_str().to_str().unwrap(), "");
     }
 
     #[test]
@@ -34,6 +34,6 @@ mod tests {
         context.append_dialect_registry(&registry);
         let module = Module::new(Location::unknown(&context));
 
-        assert_eq!(module.as_operation().print().as_str(), "\0");
+        assert_eq!(module.as_operation().print().as_str().to_str().unwrap(), "");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,3 +11,24 @@ pub mod region;
 pub mod r#type;
 pub mod utility;
 pub mod value;
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        context::Context, dialect_registry::DialectRegistry, location::Location, module::Module,
+    };
+
+    #[test]
+    fn build_module() {
+        let context = Context::new();
+        let module = Module::new(Location::unknown(&context));
+    }
+
+    #[test]
+    fn build_module_with_dialect() {
+        let registry = DialectRegistry::new();
+        let context = Context::new();
+        context.append_dialect_registry(&registry);
+        let module = Module::new(Location::unknown(&context));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,14 +61,13 @@ mod tests {
 
         let function = {
             let region = Region::new();
-            let mut block = Block::new(vec![(r#type, location), (r#type, location)]);
+            let block = Block::new(vec![(r#type, location), (r#type, location)]);
             let index_type = Type::parse(&context, "index");
 
-            block.append_operation({
+            let zero = block.append_operation({
                 let mut state = OperationState::new("arith.constant", location);
 
-                state.add_results(vec![index_type]);
-                state.add_attributes(vec![(
+                state.add_results(vec![index_type]).add_attributes(vec![(
                     Identifier::new(&context, "value"),
                     Attribute::parse(&context, "0 : index"),
                 )]);
@@ -79,11 +78,9 @@ mod tests {
             block.append_operation({
                 let mut state = OperationState::new("memref.dim", location);
 
-                state.add_operands(vec![
-                    block.argument(0),
-                    block.first_operation().unwrap().result(0),
-                ]);
-                state.add_results(vec![index_type]);
+                state
+                    .add_operands(vec![block.argument(0), zero.result(0)])
+                    .add_results(vec![index_type]);
 
                 Operation::new(state)
             });
@@ -99,17 +96,18 @@ mod tests {
 
             let mut state = OperationState::new("func.func", Location::unknown(&context));
 
-            state.add_attributes(vec![
-                (
-                    Identifier::new(&context, "function_type"),
-                    Attribute::parse(&context, "(memref<?xf32>, memref<?xf32>) -> ()"),
-                ),
-                (
-                    Identifier::new(&context, "sym_name"),
-                    Attribute::parse(&context, "\"add\""),
-                ),
-            ]);
-            state.add_regions(vec![region]);
+            state
+                .add_attributes(vec![
+                    (
+                        Identifier::new(&context, "function_type"),
+                        Attribute::parse(&context, "(memref<?xf32>, memref<?xf32>) -> ()"),
+                    ),
+                    (
+                        Identifier::new(&context, "sym_name"),
+                        Attribute::parse(&context, "\"add\""),
+                    ),
+                ])
+                .add_regions(vec![region]);
 
             Operation::new(state)
         };

--- a/src/location.rs
+++ b/src/location.rs
@@ -1,6 +1,6 @@
 use crate::{
     context::{Context, ContextRef},
-    utility::as_string_ref,
+    string_ref::StringRef,
 };
 use mlir_sys::{
     mlirLocationFileLineColGet, mlirLocationGetContext, mlirLocationUnknownGet, MlirLocation,
@@ -18,7 +18,7 @@ impl<'c> Location<'c> {
             location: unsafe {
                 mlirLocationFileLineColGet(
                     context.to_raw(),
-                    as_string_ref(filename),
+                    StringRef::from(filename).to_raw(),
                     line as u32,
                     column as u32,
                 )

--- a/src/location.rs
+++ b/src/location.rs
@@ -7,6 +7,7 @@ use mlir_sys::{
 };
 use std::marker::PhantomData;
 
+#[derive(Clone, Copy, Debug)]
 pub struct Location<'c> {
     location: MlirLocation,
     _context: PhantomData<&'c Context>,

--- a/src/location.rs
+++ b/src/location.rs
@@ -39,7 +39,7 @@ impl<'c> Location<'c> {
         unsafe { ContextRef::from_raw(mlirLocationGetContext(self.location)) }
     }
 
-    pub(crate) unsafe fn to_raw(&self) -> MlirLocation {
+    pub(crate) unsafe fn to_raw(self) -> MlirLocation {
         self.location
     }
 }

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,8 +1,12 @@
 use crate::{
     context::{Context, ContextRef},
     location::Location,
+    operation::OperationRef,
 };
-use mlir_sys::{mlirModuleCreateEmpty, mlirModuleDestroy, mlirModuleGetContext, MlirModule};
+use mlir_sys::{
+    mlirModuleCreateEmpty, mlirModuleDestroy, mlirModuleGetContext, mlirModuleGetOperation,
+    MlirModule,
+};
 use std::marker::PhantomData;
 
 pub struct Module<'c> {
@@ -16,6 +20,9 @@ impl<'c> Module<'c> {
             module: unsafe { mlirModuleCreateEmpty(location.to_raw()) },
             _context: Default::default(),
         }
+    }
+    pub fn as_operation<'a>(&'a self) -> OperationRef<'c, 'a> {
+        unsafe { OperationRef::from_raw(mlirModuleGetOperation(self.module)) }
     }
 
     pub fn context(&self) -> ContextRef<'c> {

--- a/src/module.rs
+++ b/src/module.rs
@@ -21,7 +21,7 @@ impl<'c> Module<'c> {
             _context: Default::default(),
         }
     }
-    pub fn as_operation<'a>(&'a self) -> OperationRef<'c, 'a> {
+    pub fn as_operation(&self) -> OperationRef {
         unsafe { OperationRef::from_raw(mlirModuleGetOperation(self.module)) }
     }
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,11 +1,12 @@
 use crate::{
+    block::{BlockRef, BlockRefMut},
     context::{Context, ContextRef},
     location::Location,
-    operation::OperationRef,
+    operation::{OperationRef, OperationRefMut},
 };
 use mlir_sys::{
-    mlirModuleCreateEmpty, mlirModuleDestroy, mlirModuleGetContext, mlirModuleGetOperation,
-    MlirModule,
+    mlirModuleCreateEmpty, mlirModuleDestroy, mlirModuleGetBody, mlirModuleGetContext,
+    mlirModuleGetOperation, MlirModule,
 };
 use std::marker::PhantomData;
 
@@ -21,12 +22,25 @@ impl<'c> Module<'c> {
             _context: Default::default(),
         }
     }
+
     pub fn as_operation(&self) -> OperationRef {
         unsafe { OperationRef::from_raw(mlirModuleGetOperation(self.module)) }
     }
 
+    pub fn as_operation_mut(&mut self) -> OperationRefMut {
+        unsafe { OperationRefMut::from_raw(mlirModuleGetOperation(self.module)) }
+    }
+
     pub fn context(&self) -> ContextRef<'c> {
         unsafe { ContextRef::from_raw(mlirModuleGetContext(self.module)) }
+    }
+
+    pub fn body(&self) -> BlockRef {
+        unsafe { BlockRef::from_raw(mlirModuleGetBody(self.module)) }
+    }
+
+    pub fn body_mut(&mut self) -> BlockRefMut {
+        unsafe { BlockRefMut::from_raw(mlirModuleGetBody(self.module)) }
     }
 }
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -74,12 +74,12 @@ impl<'c> Drop for Operation<'c> {
 }
 
 // TODO Should we split context lifetimes? Or, is it transitively proven that 'c > 'a?
-pub struct OperationRef<'o> {
-    operation: ManuallyDrop<Operation<'o>>,
-    _reference: PhantomData<&'o Operation<'o>>,
+pub struct OperationRef<'a> {
+    operation: ManuallyDrop<Operation<'a>>,
+    _reference: PhantomData<&'a Operation<'a>>,
 }
 
-impl<'o> OperationRef<'o> {
+impl<'a> OperationRef<'a> {
     pub(crate) unsafe fn from_raw(operation: MlirOperation) -> Self {
         Self {
             operation: ManuallyDrop::new(Operation::from_raw(operation)),
@@ -88,8 +88,8 @@ impl<'o> OperationRef<'o> {
     }
 }
 
-impl<'o> Deref for OperationRef<'o> {
-    type Target = Operation<'o>;
+impl<'a> Deref for OperationRef<'a> {
+    type Target = Operation<'a>;
 
     fn deref(&self) -> &Self::Target {
         &self.operation

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -34,7 +34,7 @@ impl<'c> Operation<'c> {
     }
 
     pub fn region(&self, index: usize) -> Region {
-        Region::from_raw(unsafe { mlirOperationGetRegion(self.operation, index as isize) })
+        unsafe { Region::from_raw(mlirOperationGetRegion(self.operation, index as isize)) }
     }
 
     pub fn print(&self) -> StringRef {

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 use mlir_sys::{
     mlirOperationCreate, mlirOperationDestroy, mlirOperationDump, mlirOperationGetContext,
-    mlirOperationGetRegion, mlirOperationGetResult, mlirOperationPrint, mlirOperationVerify,
-    MlirOperation, MlirStringRef,
+    mlirOperationGetNextInBlock, mlirOperationGetRegion, mlirOperationGetResult,
+    mlirOperationPrint, mlirOperationVerify, MlirOperation, MlirStringRef,
 };
 use std::{
     ffi::c_void,
@@ -35,11 +35,23 @@ impl<'c> Operation<'c> {
     }
 
     pub fn result(&self, index: usize) -> Value {
-        Value::from_raw(unsafe { mlirOperationGetResult(self.operation, index as isize) })
+        unsafe { Value::from_raw(mlirOperationGetResult(self.operation, index as isize)) }
     }
 
     pub fn region(&self, index: usize) -> RegionRef {
         unsafe { RegionRef::from_raw(mlirOperationGetRegion(self.operation, index as isize)) }
+    }
+
+    pub fn next_in_block(&self) -> Option<OperationRef> {
+        unsafe {
+            let operation = mlirOperationGetNextInBlock(self.operation);
+
+            if operation.ptr.is_null() {
+                None
+            } else {
+                Some(OperationRef::from_raw(operation))
+            }
+        }
     }
 
     pub fn verify(&self) -> bool {

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -5,8 +5,8 @@ use crate::{
     value::Value,
 };
 use mlir_sys::{
-    mlirOperationCreate, mlirOperationDestroy, mlirOperationGetContext, mlirOperationGetResult,
-    mlirOperationPrint, MlirOperation, MlirStringRef,
+    mlirOperationCreate, mlirOperationDestroy, mlirOperationDump, mlirOperationGetContext,
+    mlirOperationGetResult, mlirOperationPrint, MlirOperation, MlirStringRef,
 };
 use std::{ffi::c_void, marker::PhantomData, mem::ManuallyDrop, ops::Deref};
 
@@ -47,6 +47,10 @@ impl<'c> Operation<'c> {
 
             StringRef::from_raw(string.unwrap())
         }
+    }
+
+    pub fn dump(&self) {
+        unsafe { mlirOperationDump(self.operation) }
     }
 
     pub(crate) unsafe fn from_raw(operation: MlirOperation) -> Self {

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -1,12 +1,14 @@
 use crate::{
     context::{Context, ContextRef},
     operation_state::OperationState,
+    region::Region,
     string_ref::StringRef,
     value::Value,
 };
 use mlir_sys::{
     mlirOperationCreate, mlirOperationDestroy, mlirOperationDump, mlirOperationGetContext,
-    mlirOperationGetResult, mlirOperationPrint, MlirOperation, MlirStringRef,
+    mlirOperationGetRegion, mlirOperationGetResult, mlirOperationPrint, MlirOperation,
+    MlirStringRef,
 };
 use std::{ffi::c_void, marker::PhantomData, mem::ManuallyDrop, ops::Deref};
 
@@ -27,8 +29,12 @@ impl<'c> Operation<'c> {
         unsafe { ContextRef::from_raw(mlirOperationGetContext(self.operation)) }
     }
 
-    pub fn result(&self, index: usize) -> Value {
+    pub fn result(&self, index: usize) -> Value<'c> {
         Value::from_raw(unsafe { mlirOperationGetResult(self.operation, index as isize) })
+    }
+
+    pub fn region(&self, index: usize) -> Region {
+        Region::from_raw(unsafe { mlirOperationGetRegion(self.operation, index as isize) })
     }
 
     pub fn print(&self) -> StringRef {

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -76,14 +76,14 @@ impl<'c> Drop for Operation<'c> {
 // TODO Should we split context lifetimes? Or, is it transitively proven that 'c > 'a?
 pub struct OperationRef<'o> {
     operation: ManuallyDrop<Operation<'o>>,
-    _operation: PhantomData<&'o Operation<'o>>,
+    _reference: PhantomData<&'o Operation<'o>>,
 }
 
 impl<'o> OperationRef<'o> {
     pub(crate) unsafe fn from_raw(operation: MlirOperation) -> Self {
         Self {
             operation: ManuallyDrop::new(Operation::from_raw(operation)),
-            _operation: Default::default(),
+            _reference: Default::default(),
         }
     }
 }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -57,6 +57,12 @@ impl<'c> Operation<'c> {
     }
 }
 
+impl<'c> Drop for Operation<'c> {
+    fn drop(&mut self) {
+        unsafe { mlirOperationDestroy(self.operation) };
+    }
+}
+
 pub struct OperationRef<'c, 'o> {
     operation: ManuallyDrop<Operation<'c>>,
     _operation: PhantomData<&'o Operation<'c>>,
@@ -76,12 +82,6 @@ impl<'c, 'o> Deref for OperationRef<'c, 'o> {
 
     fn deref(&self) -> &Self::Target {
         &self.operation
-    }
-}
-
-impl<'c> Drop for Operation<'c> {
-    fn drop(&mut self) {
-        unsafe { mlirOperationDestroy(self.operation) };
     }
 }
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -1,7 +1,7 @@
 use crate::{
     context::{Context, ContextRef},
     operation_state::OperationState,
-    region::Region,
+    region::RegionRef,
     string_ref::StringRef,
     value::Value,
 };
@@ -33,8 +33,8 @@ impl<'c> Operation<'c> {
         Value::from_raw(unsafe { mlirOperationGetResult(self.operation, index as isize) })
     }
 
-    pub fn region(&self, index: usize) -> Region {
-        unsafe { Region::from_raw(mlirOperationGetRegion(self.operation, index as isize)) }
+    pub fn region(&self, index: usize) -> RegionRef {
+        unsafe { RegionRef::from_raw(mlirOperationGetRegion(self.operation, index as isize)) }
     }
 
     pub fn print(&self) -> StringRef {

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -63,12 +63,12 @@ impl<'c> Drop for Operation<'c> {
     }
 }
 
-pub struct OperationRef<'c, 'o> {
-    operation: ManuallyDrop<Operation<'c>>,
-    _operation: PhantomData<&'o Operation<'c>>,
+pub struct OperationRef<'o> {
+    operation: ManuallyDrop<Operation<'o>>,
+    _operation: PhantomData<&'o Operation<'o>>,
 }
 
-impl<'c, 'o> OperationRef<'c, 'o> {
+impl<'o> OperationRef<'o> {
     pub(crate) unsafe fn from_raw(operation: MlirOperation) -> Self {
         Self {
             operation: ManuallyDrop::new(Operation::from_raw(operation)),
@@ -77,8 +77,8 @@ impl<'c, 'o> OperationRef<'c, 'o> {
     }
 }
 
-impl<'c, 'o> Deref for OperationRef<'c, 'o> {
-    type Target = Operation<'c>;
+impl<'o> Deref for OperationRef<'o> {
+    type Target = Operation<'o>;
 
     fn deref(&self) -> &Self::Target {
         &self.operation

--- a/src/operation_state.rs
+++ b/src/operation_state.rs
@@ -75,7 +75,12 @@ impl<'c> OperationState<'c> {
             mlirOperationStateAddSuccessors(
                 &mut self.state,
                 successors.len() as isize,
-                into_raw_array(successors.iter().map(|block| block.to_raw()).collect()),
+                into_raw_array(
+                    successors
+                        .into_iter()
+                        .map(|block| block.into_raw())
+                        .collect(),
+                ),
             )
         }
 

--- a/src/operation_state.rs
+++ b/src/operation_state.rs
@@ -58,7 +58,12 @@ impl<'c> OperationState<'c> {
             mlirOperationStateAddOwnedRegions(
                 &mut self.state,
                 regions.len() as isize,
-                into_raw_array(regions.iter().map(|region| region.to_raw()).collect()),
+                into_raw_array(
+                    regions
+                        .into_iter()
+                        .map(|region| region.into_raw())
+                        .collect(),
+                ),
             )
         }
 

--- a/src/operation_state.rs
+++ b/src/operation_state.rs
@@ -1,13 +1,7 @@
 use crate::{
-    attribute::Attribute,
-    block::Block,
-    context::Context,
-    identifier::Identifier,
-    location::Location,
-    r#type::Type,
-    region::Region,
-    utility::{as_string_ref, into_raw_array},
-    value::Value,
+    attribute::Attribute, block::Block, context::Context, identifier::Identifier,
+    location::Location, r#type::Type, region::Region, string_ref::StringRef,
+    utility::into_raw_array, value::Value,
 };
 use mlir_sys::{
     mlirNamedAttributeGet, mlirOperationStateAddAttributes, mlirOperationStateAddOperands,
@@ -24,7 +18,9 @@ pub struct OperationState<'c> {
 impl<'c> OperationState<'c> {
     pub fn new(name: &str, location: Location<'c>) -> Self {
         Self {
-            state: unsafe { mlirOperationStateGet(as_string_ref(name), location.to_raw()) },
+            state: unsafe {
+                mlirOperationStateGet(StringRef::from(name).to_raw(), location.to_raw())
+            },
             _context: Default::default(),
         }
     }

--- a/src/operation_state.rs
+++ b/src/operation_state.rs
@@ -53,7 +53,7 @@ impl<'c> OperationState<'c> {
         self
     }
 
-    pub fn add_owned_regions(&mut self, regions: Vec<Region>) -> &mut Self {
+    pub fn add_regions(&mut self, regions: Vec<Region>) -> &mut Self {
         unsafe {
             mlirOperationStateAddOwnedRegions(
                 &mut self.state,
@@ -136,11 +136,11 @@ mod tests {
     }
 
     #[test]
-    fn add_owned_regions() {
+    fn add_regions() {
         let context = Context::new();
         let mut state = OperationState::new("foo", Location::unknown(&context));
 
-        state.add_owned_regions(vec![Region::new()]);
+        state.add_regions(vec![Region::new()]);
 
         Operation::new(state);
     }

--- a/src/region.rs
+++ b/src/region.rs
@@ -42,12 +42,12 @@ impl Drop for Region {
     }
 }
 
-pub struct RegionRef<'r> {
+pub struct RegionRef<'a> {
     region: ManuallyDrop<Region>,
-    _region: PhantomData<&'r Region>,
+    _region: PhantomData<&'a Region>,
 }
 
-impl<'r> RegionRef<'r> {
+impl<'a> RegionRef<'a> {
     pub(crate) unsafe fn from_raw(region: MlirRegion) -> Self {
         Self {
             region: ManuallyDrop::new(Region { region }),
@@ -56,7 +56,7 @@ impl<'r> RegionRef<'r> {
     }
 }
 
-impl<'r> Deref for RegionRef<'r> {
+impl<'a> Deref for RegionRef<'a> {
     type Target = Region;
 
     fn deref(&self) -> &Self::Target {

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,4 +1,10 @@
-use mlir_sys::{mlirRegionCreate, MlirRegion};
+use crate::block::Block;
+use mlir_sys::{mlirRegionCreate, mlirRegionDestroy, mlirRegionGetFirstBlock, MlirRegion};
+use std::{
+    marker::PhantomData,
+    mem::{forget, ManuallyDrop},
+    ops::Deref,
+};
 
 pub struct Region {
     region: MlirRegion,
@@ -11,18 +17,54 @@ impl Region {
         }
     }
 
-    pub(crate) fn from_raw(region: MlirRegion) -> Self {
+    pub fn first_block(&self) -> Block {
+        Block::from_raw(unsafe { mlirRegionGetFirstBlock(self.region) })
+    }
+
+    pub(crate) unsafe fn from_raw(region: MlirRegion) -> Self {
         Self { region }
     }
 
-    pub(crate) unsafe fn to_raw(&self) -> mlir_sys::MlirRegion {
-        self.region
+    pub(crate) unsafe fn into_raw(self) -> mlir_sys::MlirRegion {
+        let region = self.region;
+
+        forget(self);
+
+        region
     }
 }
 
 impl Default for Region {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Drop for Region {
+    fn drop(&mut self) {
+        unsafe { mlirRegionDestroy(self.region) }
+    }
+}
+
+pub struct RegionRef<'r> {
+    region: ManuallyDrop<Region>,
+    _region: PhantomData<&'r Region>,
+}
+
+impl<'r> RegionRef<'r> {
+    pub(crate) unsafe fn from_raw(region: MlirRegion) -> Self {
+        Self {
+            region: ManuallyDrop::new(Region { region }),
+            _region: Default::default(),
+        }
+    }
+}
+
+impl<'r> Deref for RegionRef<'r> {
+    type Target = Region;
+
+    fn deref(&self) -> &Self::Target {
+        &self.region
     }
 }
 

--- a/src/region.rs
+++ b/src/region.rs
@@ -11,6 +11,10 @@ impl Region {
         }
     }
 
+    pub(crate) fn from_raw(region: MlirRegion) -> Self {
+        Self { region }
+    }
+
     pub(crate) unsafe fn to_raw(&self) -> mlir_sys::MlirRegion {
         self.region
     }

--- a/src/region.rs
+++ b/src/region.rs
@@ -21,10 +21,6 @@ impl Region {
         Block::from_raw(unsafe { mlirRegionGetFirstBlock(self.region) })
     }
 
-    pub(crate) unsafe fn from_raw(region: MlirRegion) -> Self {
-        Self { region }
-    }
-
     pub(crate) unsafe fn into_raw(self) -> mlir_sys::MlirRegion {
         let region = self.region;
 

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,5 +1,8 @@
-use crate::block::Block;
-use mlir_sys::{mlirRegionCreate, mlirRegionDestroy, mlirRegionGetFirstBlock, MlirRegion};
+use crate::block::{Block, BlockRef};
+use mlir_sys::{
+    mlirRegionAppendOwnedBlock, mlirRegionCreate, mlirRegionDestroy, mlirRegionGetFirstBlock,
+    MlirRegion,
+};
 use std::{
     marker::PhantomData,
     mem::{forget, ManuallyDrop},
@@ -17,8 +20,12 @@ impl Region {
         }
     }
 
-    pub fn first_block(&self) -> Block {
-        Block::from_raw(unsafe { mlirRegionGetFirstBlock(self.region) })
+    pub fn first_block(&self) -> BlockRef {
+        unsafe { BlockRef::from_raw(mlirRegionGetFirstBlock(self.region)) }
+    }
+
+    pub fn append_block(&self, block: Block) {
+        unsafe { mlirRegionAppendOwnedBlock(self.region, block.into_raw()) }
     }
 
     pub(crate) unsafe fn into_raw(self) -> mlir_sys::MlirRegion {

--- a/src/region.rs
+++ b/src/region.rs
@@ -6,7 +6,7 @@ use mlir_sys::{
 use std::{
     marker::PhantomData,
     mem::{forget, ManuallyDrop},
-    ops::Deref,
+    ops::{Deref, DerefMut},
 };
 
 pub struct Region {
@@ -68,6 +68,34 @@ impl<'a> Deref for RegionRef<'a> {
 
     fn deref(&self) -> &Self::Target {
         &self.region
+    }
+}
+
+pub struct RegionRefMut<'a> {
+    region: ManuallyDrop<Region>,
+    _region: PhantomData<&'a mut Region>,
+}
+
+impl<'a> RegionRefMut<'a> {
+    pub(crate) unsafe fn from_raw(region: MlirRegion) -> Self {
+        Self {
+            region: ManuallyDrop::new(Region { region }),
+            _region: Default::default(),
+        }
+    }
+}
+
+impl<'a> Deref for RegionRefMut<'a> {
+    type Target = Region;
+
+    fn deref(&self) -> &Self::Target {
+        &self.region
+    }
+}
+
+impl<'a> DerefMut for RegionRefMut<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.region
     }
 }
 

--- a/src/string_ref.rs
+++ b/src/string_ref.rs
@@ -1,12 +1,6 @@
 use mlir_sys::{mlirStringRefCreateFromCString, MlirStringRef};
 use once_cell::sync::Lazy;
-use std::{
-    collections::HashMap,
-    ffi::{CStr, CString},
-    marker::PhantomData,
-    slice, str,
-    sync::RwLock,
-};
+use std::{collections::HashMap, ffi::CString, marker::PhantomData, slice, str, sync::RwLock};
 
 static STRING_CACHE: Lazy<RwLock<HashMap<String, CString>>> = Lazy::new(|| Default::default());
 
@@ -20,12 +14,16 @@ pub struct StringRef<'a> {
 }
 
 impl<'a> StringRef<'a> {
-    pub fn as_str(&self) -> &CStr {
+    pub fn as_str(&self) -> &str {
         unsafe {
-            CStr::from_bytes_with_nul(slice::from_raw_parts(
-                self.string.data as *mut u8,
-                self.string.length as usize,
-            ))
+            let bytes =
+                slice::from_raw_parts(self.string.data as *mut u8, self.string.length as usize);
+
+            str::from_utf8(if bytes[bytes.len() - 1] == 0 {
+                &bytes[..bytes.len() - 1]
+            } else {
+                bytes
+            })
             .unwrap()
         }
     }

--- a/src/string_ref.rs
+++ b/src/string_ref.rs
@@ -1,17 +1,21 @@
 use mlir_sys::{mlirStringRefCreateFromCString, MlirStringRef};
-use std::{ffi::CString, slice, str};
+use std::{
+    ffi::{CStr, CString},
+    slice, str,
+};
 
 pub struct StringRef {
     string: MlirStringRef,
 }
 
 impl StringRef {
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &CStr {
         unsafe {
-            str::from_utf8_unchecked(slice::from_raw_parts(
+            CStr::from_bytes_with_nul(slice::from_raw_parts(
                 self.string.data as *mut u8,
                 self.string.length as usize,
             ))
+            .unwrap()
         }
     }
 

--- a/src/string_ref.rs
+++ b/src/string_ref.rs
@@ -1,17 +1,24 @@
 use mlir_sys::{mlirStringRefCreateFromCString, MlirStringRef};
+use once_cell::sync::Lazy;
 use std::{
+    collections::HashMap,
     ffi::{CStr, CString},
     marker::PhantomData,
     slice, str,
+    sync::RwLock,
 };
 
+static STRING_CACHE: Lazy<RwLock<HashMap<String, CString>>> = Lazy::new(|| Default::default());
+
 // https://mlir.llvm.org/docs/CAPI/#stringref
+//
+// TODO The documentation says string refs do not have to be null-terminated.
+// But it looks like some APIs do not handle strings not null-terminated?
 pub struct StringRef<'a> {
     string: MlirStringRef,
     _parent: PhantomData<&'a ()>,
 }
 
-// TODO Handle non-null terminated strings.
 impl<'a> StringRef<'a> {
     pub fn as_str(&self) -> &CStr {
         unsafe {
@@ -37,7 +44,15 @@ impl<'a> StringRef<'a> {
 
 impl From<&str> for StringRef<'_> {
     fn from(string: &str) -> Self {
-        let string = CString::new(string).unwrap();
+        if !STRING_CACHE.read().unwrap().contains_key(string) {
+            STRING_CACHE
+                .write()
+                .unwrap()
+                .insert(string.to_owned(), CString::new(string).unwrap());
+        }
+
+        let lock = STRING_CACHE.read().unwrap();
+        let string = lock.get(string).unwrap();
 
         unsafe { Self::from_raw(mlirStringRefCreateFromCString(string.as_ptr())) }
     }

--- a/src/string_ref.rs
+++ b/src/string_ref.rs
@@ -2,6 +2,7 @@ use mlir_sys::{mlirStringRefCreateFromCString, MlirStringRef};
 use once_cell::sync::Lazy;
 use std::{collections::HashMap, ffi::CString, marker::PhantomData, slice, str, sync::RwLock};
 
+// We need to pass null-terminated strings to functions in the MLIR API although Rust's strings are not.
 static STRING_CACHE: Lazy<RwLock<HashMap<String, CString>>> = Lazy::new(|| Default::default());
 
 // https://mlir.llvm.org/docs/CAPI/#stringref

--- a/src/string_ref.rs
+++ b/src/string_ref.rs
@@ -19,6 +19,10 @@ impl StringRef {
         }
     }
 
+    pub(crate) unsafe fn to_raw(&self) -> MlirStringRef {
+        self.string
+    }
+
     pub(crate) unsafe fn from_raw(string: MlirStringRef) -> Self {
         Self { string }
     }

--- a/src/string_ref.rs
+++ b/src/string_ref.rs
@@ -8,6 +8,9 @@ pub struct StringRef {
     string: MlirStringRef,
 }
 
+// https://mlir.llvm.org/docs/CAPI/#stringref
+//
+// TODO Handle non-null terminated strings.
 impl StringRef {
     pub fn as_str(&self) -> &CStr {
         unsafe {

--- a/src/string_ref.rs
+++ b/src/string_ref.rs
@@ -42,7 +42,7 @@ impl<'a> StringRef<'a> {
     }
 }
 
-impl From<&str> for StringRef<'_> {
+impl From<&str> for StringRef<'static> {
     fn from(string: &str) -> Self {
         if !STRING_CACHE.read().unwrap().contains_key(string) {
             STRING_CACHE

--- a/src/string_ref.rs
+++ b/src/string_ref.rs
@@ -3,7 +3,7 @@ use once_cell::sync::Lazy;
 use std::{collections::HashMap, ffi::CString, marker::PhantomData, slice, str, sync::RwLock};
 
 // We need to pass null-terminated strings to functions in the MLIR API although Rust's strings are not.
-static STRING_CACHE: Lazy<RwLock<HashMap<String, CString>>> = Lazy::new(|| Default::default());
+static STRING_CACHE: Lazy<RwLock<HashMap<String, CString>>> = Lazy::new(Default::default);
 
 // https://mlir.llvm.org/docs/CAPI/#stringref
 //

--- a/src/string_ref.rs
+++ b/src/string_ref.rs
@@ -13,7 +13,7 @@ static STRING_CACHE: Lazy<RwLock<HashMap<String, CString>>> = Lazy::new(|| Defau
 // https://mlir.llvm.org/docs/CAPI/#stringref
 //
 // TODO The documentation says string refs do not have to be null-terminated.
-// But it looks like some APIs do not handle strings not null-terminated?
+// But it looks like some functions do not handle strings not null-terminated?
 pub struct StringRef<'a> {
     string: MlirStringRef,
     _parent: PhantomData<&'a ()>,

--- a/src/string_ref.rs
+++ b/src/string_ref.rs
@@ -1,0 +1,31 @@
+use mlir_sys::{mlirStringRefCreateFromCString, MlirStringRef};
+use std::{ffi::CString, slice, str};
+
+pub struct StringRef {
+    string: MlirStringRef,
+}
+
+impl StringRef {
+    pub fn as_str(&self) -> &str {
+        unsafe {
+            str::from_utf8_unchecked(slice::from_raw_parts(
+                self.string.data as *mut u8,
+                self.string.length as usize,
+            ))
+        }
+    }
+
+    pub(crate) unsafe fn from_raw(string: MlirStringRef) -> Self {
+        Self { string }
+    }
+}
+
+impl From<&str> for StringRef {
+    fn from(string: &str) -> Self {
+        unsafe {
+            Self::from_raw(mlirStringRefCreateFromCString(
+                CString::new(string).unwrap().into_raw(),
+            ))
+        }
+    }
+}

--- a/src/type.rs
+++ b/src/type.rs
@@ -9,14 +9,14 @@ use std::marker::PhantomData;
 #[derive(Clone, Copy, Debug)]
 pub struct Type<'c> {
     r#type: MlirType,
-    _parent: PhantomData<&'c Context>,
+    _context: PhantomData<&'c Context>,
 }
 
 impl<'c> Type<'c> {
     pub fn parse(context: &Context, source: &str) -> Self {
         Self {
             r#type: unsafe { mlirTypeParseGet(context.to_raw(), StringRef::from(source).to_raw()) },
-            _parent: Default::default(),
+            _context: Default::default(),
         }
     }
 

--- a/src/type.rs
+++ b/src/type.rs
@@ -5,10 +5,10 @@ use crate::{
 use mlir_sys::{mlirTypeGetContext, mlirTypeParseGet, MlirType};
 use std::marker::PhantomData;
 
-// Types are always references.
-pub struct Type<'a> {
+// Types are always values but their internal storage is owned by contexts.
+pub struct Type<'c> {
     r#type: MlirType,
-    _parent: PhantomData<&'a MlirType>,
+    _parent: PhantomData<&'c Context>,
 }
 
 impl<'c> Type<'c> {

--- a/src/type.rs
+++ b/src/type.rs
@@ -24,7 +24,7 @@ impl<'c> Type<'c> {
         unsafe { ContextRef::from_raw(mlirTypeGetContext(self.r#type)) }
     }
 
-    pub(crate) unsafe fn to_raw(&self) -> MlirType {
+    pub(crate) unsafe fn to_raw(self) -> MlirType {
         self.r#type
     }
 }

--- a/src/type.rs
+++ b/src/type.rs
@@ -1,6 +1,6 @@
 use crate::{
     context::{Context, ContextRef},
-    utility::as_string_ref,
+    string_ref::StringRef,
 };
 use mlir_sys::{mlirTypeGetContext, mlirTypeParseGet, MlirType};
 use std::marker::PhantomData;
@@ -14,7 +14,7 @@ pub struct Type<'c> {
 impl<'c> Type<'c> {
     pub fn parse(context: &Context, source: &str) -> Self {
         Self {
-            r#type: unsafe { mlirTypeParseGet(context.to_raw(), as_string_ref(source)) },
+            r#type: unsafe { mlirTypeParseGet(context.to_raw(), StringRef::from(source).to_raw()) },
             _parent: Default::default(),
         }
     }

--- a/src/type.rs
+++ b/src/type.rs
@@ -5,16 +5,17 @@ use crate::{
 use mlir_sys::{mlirTypeGetContext, mlirTypeParseGet, MlirType};
 use std::marker::PhantomData;
 
-pub struct Type<'c> {
+// Types are always references.
+pub struct Type<'a> {
     r#type: MlirType,
-    _context: PhantomData<&'c Context>,
+    _parent: PhantomData<&'a MlirType>,
 }
 
 impl<'c> Type<'c> {
     pub fn parse(context: &Context, source: &str) -> Self {
         Self {
             r#type: unsafe { mlirTypeParseGet(context.to_raw(), as_string_ref(source)) },
-            _context: Default::default(),
+            _parent: Default::default(),
         }
     }
 

--- a/src/type.rs
+++ b/src/type.rs
@@ -6,6 +6,7 @@ use mlir_sys::{mlirTypeGetContext, mlirTypeParseGet, MlirType};
 use std::marker::PhantomData;
 
 // Types are always values but their internal storage is owned by contexts.
+#[derive(Clone, Copy, Debug)]
 pub struct Type<'c> {
     r#type: MlirType,
     _parent: PhantomData<&'c Context>,

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -1,11 +1,5 @@
-use crate::string_ref::StringRef;
-use mlir_sys::MlirStringRef;
 use std::mem::forget;
 use std::ptr::null_mut;
-
-pub(crate) unsafe fn as_string_ref(string: &str) -> MlirStringRef {
-    StringRef::from(string).to_raw()
-}
 
 pub(crate) unsafe fn into_raw_array<T>(mut xs: Vec<T>) -> *mut T {
     if xs.is_empty() {

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -1,14 +1,4 @@
-use std::mem::forget;
-use std::ptr::null_mut;
-
-pub(crate) unsafe fn into_raw_array<T>(mut xs: Vec<T>) -> *mut T {
-    if xs.is_empty() {
-        null_mut()
-    } else {
-        let ptr = xs.as_mut_ptr();
-
-        forget(xs);
-
-        ptr
-    }
+// TODO Use into_raw_parts.
+pub(crate) unsafe fn into_raw_array<T>(xs: Vec<T>) -> *mut T {
+    xs.leak().as_mut_ptr()
 }

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -1,16 +1,10 @@
+use crate::string_ref::StringRef;
 use mlir_sys::MlirStringRef;
-use std::ffi::CString;
 use std::mem::forget;
 use std::ptr::null_mut;
 
-// TODO Is this safe?
 pub(crate) unsafe fn as_string_ref(string: &str) -> MlirStringRef {
-    let length = string.len() as u64;
-
-    MlirStringRef {
-        data: CString::new(string).unwrap().into_raw(),
-        length,
-    }
+    StringRef::from(string).to_raw()
 }
 
 pub(crate) unsafe fn into_raw_array<T>(mut xs: Vec<T>) -> *mut T {

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -1,11 +1,13 @@
+use mlir_sys::MlirStringRef;
 use std::ffi::CString;
 use std::mem::forget;
 use std::ptr::null_mut;
 
-pub(crate) unsafe fn as_string_ref(string: &str) -> mlir_sys::MlirStringRef {
+// TODO Is this safe?
+pub(crate) unsafe fn as_string_ref(string: &str) -> MlirStringRef {
     let length = string.len() as u64;
 
-    mlir_sys::MlirStringRef {
+    MlirStringRef {
         data: CString::new(string).unwrap().into_raw(),
         length,
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -17,7 +17,7 @@ impl<'a> Value<'a> {
         }
     }
 
-    pub(crate) unsafe fn to_raw(&self) -> MlirValue {
+    pub(crate) unsafe fn to_raw(self) -> MlirValue {
         self.value
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,17 +1,17 @@
-use crate::context::Context;
 use mlir_sys::MlirValue;
 use std::marker::PhantomData;
 
-pub struct Value<'c> {
+// Values are always non-owning references.
+pub struct Value<'a> {
     value: MlirValue,
-    _context: PhantomData<&'c Context>,
+    _parent: PhantomData<&'a ()>,
 }
 
-impl<'c> Value<'c> {
+impl<'a> Value<'a> {
     pub(crate) fn from_raw(value: MlirValue) -> Self {
         Self {
             value,
-            _context: Default::default(),
+            _parent: Default::default(),
         }
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,7 +1,7 @@
 use mlir_sys::MlirValue;
 use std::marker::PhantomData;
 
-// Values are always non-owning references.
+// Values are always non-owning references. See the `Value` class in the MLIR C++ API.
 pub struct Value<'a> {
     value: MlirValue,
     _parent: PhantomData<&'a ()>,

--- a/src/value.rs
+++ b/src/value.rs
@@ -10,14 +10,14 @@ pub struct Value<'a> {
 }
 
 impl<'a> Value<'a> {
-    pub(crate) fn from_raw(value: MlirValue) -> Self {
+    pub(crate) unsafe fn from_raw(value: MlirValue) -> Self {
         Self {
             value,
             _parent: Default::default(),
         }
     }
 
-    pub(crate) fn to_raw(&self) -> MlirValue {
+    pub(crate) unsafe fn to_raw(&self) -> MlirValue {
         self.value
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 
 // Values are always non-owning references to their parents, such as operations and block arguments.
 // See the `Value` class in the MLIR C++ API.
+#[derive(Clone, Copy, Debug)]
 pub struct Value<'a> {
     value: MlirValue,
     _parent: PhantomData<&'a ()>,

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,12 +1,18 @@
+use crate::context::Context;
 use mlir_sys::MlirValue;
+use std::marker::PhantomData;
 
-pub struct Value {
+pub struct Value<'c> {
     value: MlirValue,
+    _context: PhantomData<&'c Context>,
 }
 
-impl Value {
+impl<'c> Value<'c> {
     pub(crate) fn from_raw(value: MlirValue) -> Self {
-        Self { value }
+        Self {
+            value,
+            _context: Default::default(),
+        }
     }
 
     pub(crate) fn to_raw(&self) -> MlirValue {

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,7 +1,8 @@
 use mlir_sys::MlirValue;
 use std::marker::PhantomData;
 
-// Values are always non-owning references. See the `Value` class in the MLIR C++ API.
+// Values are always non-owning references to their parents, such as operations and block arguments.
+// See the `Value` class in the MLIR C++ API.
 pub struct Value<'a> {
     value: MlirValue,
     _parent: PhantomData<&'a ()>,

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -8,10 +8,8 @@ set -e
 # brew update
 # brew install llvm@$llvm_version
 
+# echo PATH=$(brew --prefix)/opt/llvm@$llvm_version/bin:$PATH >>$GITHUB_ENV
+
 curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s 15 all
 sudo apt -y install libmlir-15-dev mlir-15-tools
 echo PATH=/usr/lib/llvm-15/bin:$PATH >>$GITHUB_ENV
-
-if [ -n "$GITHUB_ENV" ]; then
-  echo PATH=$(brew --prefix)/opt/llvm@$llvm_version/bin:$PATH >>$GITHUB_ENV
-fi

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -2,10 +2,14 @@
 
 set -e
 
-llvm_version=14
+# TODO Use Homebrew to install LLVM 15.
+# llvm_version=15
 
-brew update
-brew install llvm@$llvm_version
+# brew update
+# brew install llvm@$llvm_version
+
+curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s 15 all
+sudo apt -y install libmlir-15-dev mlir-15-tools
 
 if [ -n "$GITHUB_ENV" ]; then
   echo PATH=$(brew --prefix)/opt/llvm@$llvm_version/bin:$PATH >>$GITHUB_ENV

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -10,6 +10,7 @@ set -e
 
 curl -fsSL https://apt.llvm.org/llvm.sh | sudo bash -s 15 all
 sudo apt -y install libmlir-15-dev mlir-15-tools
+echo PATH=/usr/lib/llvm-15/bin:$PATH >>$GITHUB_ENV
 
 if [ -n "$GITHUB_ENV" ]; then
   echo PATH=$(brew --prefix)/opt/llvm@$llvm_version/bin:$PATH >>$GITHUB_ENV


### PR DESCRIPTION
# Todo

- Use options for appropriate places.
  - e.g. `argument`, `result`
- Refactor the operation state API.