### PR TITLE
`Result<T, E>` as general failures

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ pub enum Error {
     FunctionExpected(String),
     InvokeFunction,
     OperationResultPosition(String, usize),
+    RunPass,
     ParsePassPipeline,
 }
 
@@ -32,7 +33,8 @@ impl Display for Error {
                     position, operation
                 )
             }
-            Self::ParsePassPipeline => write!(formatter, "parse pass pipeline"),
+            Self::RunPass => write!(formatter, "failed to run pass"),
+            Self::ParsePassPipeline => write!(formatter, "failed to parse pass pipeline"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-use crate::ir::Type;
 use std::{
     error,
     fmt::{self, Display, Formatter},
@@ -6,16 +5,32 @@ use std::{
 
 /// A Melior error.
 #[derive(Debug, Eq, PartialEq)]
-pub enum Error<'c> {
-    FunctionExpected(Type<'c>),
+pub enum Error {
+    BlockArgumentPosition(String, usize),
+    FunctionExpected(String),
+    OperationResultPosition(String, usize),
 }
 
-impl<'c> Display for Error<'c> {
+impl Display for Error {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match self {
+            Self::BlockArgumentPosition(block, position) => {
+                write!(
+                    formatter,
+                    "block argument position {} out of range: {}",
+                    position, block
+                )
+            }
             Self::FunctionExpected(r#type) => write!(formatter, "function expected: {}", r#type),
+            Self::OperationResultPosition(operation, position) => {
+                write!(
+                    formatter,
+                    "operation result position {} out of range: {}",
+                    position, operation
+                )
+            }
         }
     }
 }
 
-impl<'c> error::Error for Error<'c> {}
+impl error::Error for Error {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,9 @@ use std::{
 pub enum Error {
     BlockArgumentPosition(String, usize),
     FunctionExpected(String),
+    InvokeFunction,
     OperationResultPosition(String, usize),
+    ParsePassPipeline,
 }
 
 impl Display for Error {
@@ -22,6 +24,7 @@ impl Display for Error {
                 )
             }
             Self::FunctionExpected(r#type) => write!(formatter, "function expected: {}", r#type),
+            Self::InvokeFunction => write!(formatter, "failed to invoke JIT-compiled function"),
             Self::OperationResultPosition(operation, position) => {
                 write!(
                     formatter,
@@ -29,6 +32,7 @@ impl Display for Error {
                     position, operation
                 )
             }
+            Self::ParsePassPipeline => write!(formatter, "parse pass pipeline"),
         }
     }
 }

--- a/src/execution_engine.rs
+++ b/src/execution_engine.rs
@@ -96,7 +96,7 @@ mod tests {
             .nested_under("func.func")
             .add_pass(pass::conversion::convert_arithmetic_to_llvm());
 
-        assert!(pass_manager.run(&mut module).is_success());
+        assert_eq!(pass_manager.run(&mut module), Ok(()));
 
         let engine = ExecutionEngine::new(&module, 2, &[]);
 

--- a/src/execution_engine.rs
+++ b/src/execution_engine.rs
@@ -103,16 +103,18 @@ mod tests {
         let mut argument = 42;
         let mut result = -1;
 
-        assert!(unsafe {
-            engine.invoke_packed(
-                "add",
-                &mut [
-                    &mut argument as *mut i32 as *mut (),
-                    &mut result as *mut i32 as *mut (),
-                ],
-            )
-        }
-        .is_success());
+        assert_eq!(
+            unsafe {
+                engine.invoke_packed(
+                    "add",
+                    &mut [
+                        &mut argument as *mut i32 as *mut (),
+                        &mut result as *mut i32 as *mut (),
+                    ],
+                )
+            },
+            Ok(())
+        );
 
         assert_eq!(argument, 42);
         assert_eq!(result, 84);

--- a/src/ir/operation.rs
+++ b/src/ir/operation.rs
@@ -7,6 +7,7 @@ use super::{BlockRef, Identifier, OperationResult, RegionRef, Value};
 use crate::{
     context::{Context, ContextRef},
     string_ref::StringRef,
+    Error,
 };
 use core::fmt;
 use mlir_sys::{
@@ -95,15 +96,15 @@ impl<'a> OperationRef<'a> {
         unsafe { BlockRef::from_option_raw(mlirOperationGetBlock(self.raw)) }
     }
 
-    /// Gets a result at an index.
-    pub fn result(&self, index: usize) -> Option<OperationResult> {
+    /// Gets a result at a position.
+    pub fn result(&self, position: usize) -> Result<OperationResult, Error> {
         unsafe {
-            if index < self.result_count() as usize {
-                Some(OperationResult::from_value(Value::from_raw(
-                    mlirOperationGetResult(self.raw, index as isize),
+            if position < self.result_count() as usize {
+                Ok(OperationResult::from_value(Value::from_raw(
+                    mlirOperationGetResult(self.raw, position as isize),
                 )))
             } else {
-                None
+                Err(Error::OperationResultPosition(self.to_string(), position))
             }
         }
     }
@@ -216,6 +217,7 @@ mod tests {
         context::Context,
         ir::{Block, Location},
     };
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn new() {
@@ -255,10 +257,13 @@ mod tests {
 
     #[test]
     fn result_none() {
-        assert!(Builder::new("foo", Location::unknown(&Context::new()),)
-            .build()
-            .result(0)
-            .is_none());
+        assert_eq!(
+            Builder::new("foo", Location::unknown(&Context::new()))
+                .build()
+                .result(0)
+                .unwrap_err(),
+            Error::OperationResultPosition("\"foo\"".into(), 0)
+        );
     }
 
     #[test]

--- a/src/ir/operation.rs
+++ b/src/ir/operation.rs
@@ -256,13 +256,13 @@ mod tests {
     }
 
     #[test]
-    fn result_none() {
+    fn result_error() {
         assert_eq!(
             Builder::new("foo", Location::unknown(&Context::new()))
                 .build()
                 .result(0)
                 .unwrap_err(),
-            Error::OperationResultPosition("\"foo\"".into(), 0)
+            Error::OperationResultPosition("\"foo\"() : () -> ()\n".into(), 0)
         );
     }
 

--- a/src/ir/type.rs
+++ b/src/ir/type.rs
@@ -122,7 +122,7 @@ impl<'c> Type<'c> {
     pub fn input(&self, position: usize) -> Result<Option<Self>, Error> {
         unsafe {
             if !mlirTypeIsAFunction(self.raw) {
-                return Err(Error::FunctionExpected(*self));
+                return Err(Error::FunctionExpected(self.to_string()));
             }
 
             Ok(Self::from_option_raw(mlirFunctionTypeGetInput(
@@ -136,7 +136,7 @@ impl<'c> Type<'c> {
     pub fn result(&self, position: usize) -> Result<Option<Self>, Error> {
         unsafe {
             if !mlirTypeIsAFunction(self.raw) {
-                return Err(Error::FunctionExpected(*self));
+                return Err(Error::FunctionExpected(self.to_string()));
             }
 
             Ok(Self::from_option_raw(mlirFunctionTypeGetResult(
@@ -150,7 +150,7 @@ impl<'c> Type<'c> {
     pub fn input_count(&self) -> Result<usize, Error> {
         unsafe {
             if !mlirTypeIsAFunction(self.raw) {
-                return Err(Error::FunctionExpected(*self));
+                return Err(Error::FunctionExpected(self.to_string()));
             }
 
             Ok(mlirFunctionTypeGetNumInputs(self.raw) as usize)
@@ -161,7 +161,7 @@ impl<'c> Type<'c> {
     pub fn result_count(&self) -> Result<usize, Error> {
         unsafe {
             if !mlirTypeIsAFunction(self.raw) {
-                return Err(Error::FunctionExpected(*self));
+                return Err(Error::FunctionExpected(self.to_string()));
             }
 
             Ok(mlirFunctionTypeGetNumResults(self.raw) as usize)
@@ -390,7 +390,10 @@ mod tests {
             let context = Context::new();
             let r#type = Type::integer(&context, 42);
 
-            assert_eq!(r#type.input(0), Err(Error::FunctionExpected(r#type)));
+            assert_eq!(
+                r#type.input(0),
+                Err(Error::FunctionExpected(r#type.to_string()))
+            );
         }
 
         #[test]
@@ -409,7 +412,10 @@ mod tests {
             let context = Context::new();
             let r#type = Type::integer(&context, 42);
 
-            assert_eq!(r#type.result(0), Err(Error::FunctionExpected(r#type)));
+            assert_eq!(
+                r#type.result(0),
+                Err(Error::FunctionExpected(r#type.to_string()))
+            );
         }
 
         #[test]
@@ -428,7 +434,10 @@ mod tests {
             let context = Context::new();
             let r#type = Type::integer(&context, 42);
 
-            assert_eq!(r#type.input_count(), Err(Error::FunctionExpected(r#type)));
+            assert_eq!(
+                r#type.input_count(),
+                Err(Error::FunctionExpected(r#type.to_string()))
+            );
         }
 
         #[test]
@@ -447,7 +456,10 @@ mod tests {
             let context = Context::new();
             let r#type = Type::integer(&context, 42);
 
-            assert_eq!(r#type.result_count(), Err(Error::FunctionExpected(r#type)));
+            assert_eq!(
+                r#type.result_count(),
+                Err(Error::FunctionExpected(r#type.to_string()))
+            );
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,8 +86,7 @@ mod string_ref;
 pub mod utility;
 
 pub use self::{
-    context::Context, error::Error, execution_engine::ExecutionEngine,
-    logical_result::LogicalResult, string_ref::StringRef,
+    context::Context, error::Error, execution_engine::ExecutionEngine, string_ref::StringRef,
 };
 
 #[cfg(test)]

--- a/src/logical_result.rs
+++ b/src/logical_result.rs
@@ -5,6 +5,8 @@ pub(crate) struct LogicalResult {
     raw: MlirLogicalResult,
 }
 
+// TODO Delete this and replace it with `bool`?
+#[allow(unused)]
 impl LogicalResult {
     /// Creates a success result.
     pub fn success() -> Self {

--- a/src/logical_result.rs
+++ b/src/logical_result.rs
@@ -1,7 +1,7 @@
 use mlir_sys::MlirLogicalResult;
 
 /// A logical result of success or failure.
-pub struct LogicalResult {
+pub(crate) struct LogicalResult {
     raw: MlirLogicalResult,
 }
 

--- a/src/pass/manager.rs
+++ b/src/pass/manager.rs
@@ -1,6 +1,7 @@
 use super::OperationManager;
 use crate::{
     context::Context, ir::Module, logical_result::LogicalResult, pass::Pass, string_ref::StringRef,
+    Error,
 };
 use mlir_sys::{
     mlirPassManagerAddOwnedPass, mlirPassManagerCreate, mlirPassManagerDestroy,
@@ -52,8 +53,15 @@ impl<'c> Manager<'c> {
     }
 
     /// Runs passes added to a pass manager against a module.
-    pub fn run(&self, module: &mut Module) -> LogicalResult {
-        LogicalResult::from_raw(unsafe { mlirPassManagerRun(self.raw, module.to_raw()) })
+    pub fn run(&self, module: &mut Module) -> Result<(), Error> {
+        let result =
+            LogicalResult::from_raw(unsafe { mlirPassManagerRun(self.raw, module.to_raw()) });
+
+        if result.is_success() {
+            Ok(())
+        } else {
+            Err(Error::RunPass)
+        }
     }
 
     /// Converts a pass manager to an operation pass manager.

--- a/src/pass/manager.rs
+++ b/src/pass/manager.rs
@@ -76,6 +76,7 @@ mod tests {
         ir::{Location, Module},
         pass::{self, transform::register_print_operation_stats},
         utility::{parse_pass_pipeline, register_all_dialects},
+        Error,
     };
     use indoc::indoc;
     use pretty_assertions::assert_eq;
@@ -214,21 +215,25 @@ mod tests {
         let context = Context::new();
         let manager = Manager::new(&context);
 
-        assert!(parse_pass_pipeline(
-            manager.as_operation_pass_manager(),
-            "builtin.module(func.func(print-op-stats{json=false}),\
+        assert_eq!(
+            parse_pass_pipeline(
+                manager.as_operation_pass_manager(),
+                "builtin.module(func.func(print-op-stats{json=false}),\
                 func.func(print-op-stats{json=false}))"
-        )
-        .is_failure());
+            ),
+            Err(Error::ParsePassPipeline)
+        );
 
         register_print_operation_stats();
 
-        assert!(parse_pass_pipeline(
-            manager.as_operation_pass_manager(),
-            "builtin.module(func.func(print-op-stats{json=false}),\
+        assert_eq!(
+            parse_pass_pipeline(
+                manager.as_operation_pass_manager(),
+                "builtin.module(func.func(print-op-stats{json=false}),\
                 func.func(print-op-stats{json=false}))"
-        )
-        .is_success());
+            ),
+            Ok(())
+        );
 
         assert_eq!(
             manager.as_operation_pass_manager().to_string(),

--- a/src/pass/manager.rs
+++ b/src/pass/manager.rs
@@ -130,7 +130,9 @@ mod tests {
         let manager = Manager::new(&context);
 
         manager.add_pass(pass::conversion::convert_func_to_llvm());
-        manager.run(&mut Module::new(Location::unknown(&context)));
+        manager
+            .run(&mut Module::new(Location::unknown(&context)))
+            .unwrap();
     }
 
     #[test]
@@ -154,7 +156,7 @@ mod tests {
         let manager = Manager::new(&context);
         manager.add_pass(pass::transform::print_operation_stats());
 
-        assert!(manager.run(&mut module).is_success());
+        assert_eq!(manager.run(&mut module), Ok(()));
     }
 
     #[test]
@@ -187,7 +189,7 @@ mod tests {
             .nested_under("func.func")
             .add_pass(pass::transform::print_operation_stats());
 
-        assert!(manager.run(&mut module).is_success());
+        assert_eq!(manager.run(&mut module), Ok(()));
 
         let manager = Manager::new(&context);
         manager
@@ -195,7 +197,7 @@ mod tests {
             .nested_under("func.func")
             .add_pass(pass::transform::print_operation_stats());
 
-        assert!(manager.run(&mut module).is_success());
+        assert_eq!(manager.run(&mut module), Ok(()));
     }
 
     #[test]

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -1,7 +1,7 @@
 //! Utility functions.
 
 use crate::{
-    context::Context, dialect, logical_result::LogicalResult, pass, string_ref::StringRef,
+    context::Context, dialect, logical_result::LogicalResult, pass, string_ref::StringRef, Error,
 };
 use mlir_sys::{
     mlirParsePassPipeline, mlirRegisterAllDialects, mlirRegisterAllLLVMTranslations,
@@ -28,10 +28,16 @@ pub fn register_all_passes() {
 }
 
 /// Parses a pass pipeline.
-pub fn parse_pass_pipeline(manager: pass::OperationManager, source: &str) -> LogicalResult {
-    LogicalResult::from_raw(unsafe {
+pub fn parse_pass_pipeline(manager: pass::OperationManager, source: &str) -> Result<(), Error> {
+    let result = LogicalResult::from_raw(unsafe {
         mlirParsePassPipeline(manager.to_raw(), StringRef::from(source).to_raw())
-    })
+    });
+
+    if result.is_success() {
+        Ok(())
+    } else {
+        Err(Error::ParsePassPipeline)
+    }
 }
 
 // TODO Use into_raw_parts.


### PR DESCRIPTION
Close #47.
