### PR TITLE
Use unsafe transmute for `Deref` of `*Ref`s

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -95,7 +95,7 @@ impl Default for Context {
     }
 }
 
-impl<'a> PartialEq for Context {
+impl PartialEq for Context {
     fn eq(&self, other: &Self) -> bool {
         unsafe { mlirContextEqual(self.raw, other.raw) }
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,7 +9,7 @@ use mlir_sys::{
     mlirContextGetOrLoadDialect, mlirContextIsRegisteredOperation,
     mlirContextLoadAllAvailableDialects, mlirContextSetAllowUnregisteredDialects, MlirContext,
 };
-use std::{marker::PhantomData, ops::Deref};
+use std::{borrow::Borrow, marker::PhantomData, ops::Deref};
 
 /// A context of IR, dialects, and passes.
 ///
@@ -45,6 +45,12 @@ impl Deref for Context {
     type Target = ContextRef<'static>;
 
     fn deref(&self) -> &Self::Target {
+        &self.r#ref
+    }
+}
+
+impl<'a> Borrow<ContextRef<'a>> for &'a Context {
+    fn borrow(&self) -> &ContextRef<'a> {
         &self.r#ref
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,7 +9,7 @@ use mlir_sys::{
     mlirContextGetOrLoadDialect, mlirContextIsRegisteredOperation,
     mlirContextLoadAllAvailableDialects, mlirContextSetAllowUnregisteredDialects, MlirContext,
 };
-use std::{marker::PhantomData, ops::Deref};
+use std::{marker::PhantomData, mem::transmute, ops::Deref};
 
 /// A context of IR, dialects, and passes.
 ///
@@ -17,46 +17,17 @@ use std::{marker::PhantomData, ops::Deref};
 /// instances.
 #[derive(Debug)]
 pub struct Context {
-    r#ref: ContextRef<'static>,
+    raw: MlirContext,
 }
 
 impl Context {
     /// Creates a context.
     pub fn new() -> Self {
         Self {
-            r#ref: unsafe { ContextRef::from_raw(mlirContextCreate()) },
+            raw: unsafe { mlirContextCreate() },
         }
     }
-}
 
-impl Drop for Context {
-    fn drop(&mut self) {
-        unsafe { mlirContextDestroy(self.raw) };
-    }
-}
-
-impl Default for Context {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Deref for Context {
-    type Target = ContextRef<'static>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.r#ref
-    }
-}
-
-/// A reference to a context.
-#[derive(Clone, Copy, Debug)]
-pub struct ContextRef<'a> {
-    raw: MlirContext,
-    _reference: PhantomData<&'a Context>,
-}
-
-impl<'a> ContextRef<'a> {
     /// Gets a number of registered dialects.
     pub fn registered_dialect_count(&self) -> usize {
         unsafe { mlirContextGetNumRegisteredDialects(self.raw) as usize }
@@ -107,15 +78,44 @@ impl<'a> ContextRef<'a> {
         unsafe { mlirContextIsRegisteredOperation(self.raw, StringRef::from(name).to_raw()) }
     }
 
-    pub(crate) unsafe fn to_raw(self) -> MlirContext {
+    pub(crate) unsafe fn to_raw(&self) -> MlirContext {
         self.raw
     }
+}
 
+impl Drop for Context {
+    fn drop(&mut self) {
+        unsafe { mlirContextDestroy(self.raw) };
+    }
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A reference to a context.
+#[derive(Clone, Copy, Debug)]
+pub struct ContextRef<'a> {
+    raw: MlirContext,
+    _reference: PhantomData<&'a Context>,
+}
+
+impl<'a> ContextRef<'a> {
     pub(crate) unsafe fn from_raw(raw: MlirContext) -> Self {
         Self {
             raw,
             _reference: Default::default(),
         }
+    }
+}
+
+impl<'a> Deref for ContextRef<'a> {
+    type Target = Context;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { transmute(self) }
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -95,6 +95,14 @@ impl Default for Context {
     }
 }
 
+impl<'a> PartialEq for Context {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { mlirContextEqual(self.raw, other.raw) }
+    }
+}
+
+impl Eq for Context {}
+
 /// A reference to a context.
 #[derive(Clone, Copy, Debug)]
 pub struct ContextRef<'a> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,7 +9,7 @@ use mlir_sys::{
     mlirContextGetOrLoadDialect, mlirContextIsRegisteredOperation,
     mlirContextLoadAllAvailableDialects, mlirContextSetAllowUnregisteredDialects, MlirContext,
 };
-use std::{borrow::Borrow, marker::PhantomData, ops::Deref};
+use std::{marker::PhantomData, ops::Deref};
 
 /// A context of IR, dialects, and passes.
 ///
@@ -45,12 +45,6 @@ impl Deref for Context {
     type Target = ContextRef<'static>;
 
     fn deref(&self) -> &Self::Target {
-        &self.r#ref
-    }
-}
-
-impl<'a> Borrow<ContextRef<'a>> for &'a Context {
-    fn borrow(&self) -> &ContextRef<'a> {
         &self.r#ref
     }
 }

--- a/src/ir/block.rs
+++ b/src/ir/block.rs
@@ -303,6 +303,7 @@ mod tests {
         ir::{operation, Module, Region, ValueLike},
         utility::register_all_dialects,
     };
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn new() {
@@ -504,7 +505,7 @@ mod tests {
     fn debug() {
         assert_eq!(
             format!("{:?}", &Block::new(&[])),
-            "BlockRef(\n<<UNLINKED BLOCK>>\n)"
+            "Block(\n<<UNLINKED BLOCK>>\n)"
         );
     }
 }

--- a/src/ir/block.rs
+++ b/src/ir/block.rs
@@ -213,12 +213,6 @@ impl<'c> PartialEq for Block<'c> {
 
 impl<'c> Eq for Block<'c> {}
 
-impl<'c, 'a> AsRef<BlockRef<'a>> for Block<'c> {
-    fn as_ref(&self) -> &BlockRef<'a> {
-        unsafe { transmute(self) }
-    }
-}
-
 impl<'c> Display for Block<'c> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         let mut data = (formatter, Ok(()));
@@ -342,7 +336,7 @@ mod tests {
         let region = Region::new();
         let block = region.append_block(Block::new(&[]));
 
-        assert_eq!(block.parent_region(), Some(*region.as_ref()));
+        assert_eq!(block.parent_region().as_deref(), Some(&region));
     }
 
     #[test]

--- a/src/ir/block.rs
+++ b/src/ir/block.rs
@@ -342,7 +342,7 @@ mod tests {
         let region = Region::new();
         let block = region.append_block(Block::new(&[]));
 
-        assert_eq!(block.parent_region(), Some(*region));
+        assert_eq!(block.parent_region(), Some(*region.as_ref()));
     }
 
     #[test]

--- a/src/ir/block/argument.rs
+++ b/src/ir/block/argument.rs
@@ -81,7 +81,7 @@ mod tests {
         let r#type = Type::parse(&context, "index").unwrap();
         let block = Block::new(&[(r#type, Location::unknown(&context))]);
 
-        assert_eq!(block.argument(0).unwrap().owner(), *block);
+        assert_eq!(&*block.argument(0).unwrap().owner(), &block);
     }
 
     #[test]

--- a/src/ir/operation.rs
+++ b/src/ir/operation.rs
@@ -198,14 +198,6 @@ impl<'a> OperationRef<'a> {
     }
 }
 
-impl<'a> PartialEq for OperationRef<'a> {
-    fn eq(&self, other: &Self) -> bool {
-        unsafe { mlirOperationEqual(self.raw, other.raw) }
-    }
-}
-
-impl<'a> Eq for OperationRef<'a> {}
-
 impl<'a> Deref for OperationRef<'a> {
     type Target = Operation<'a>;
 
@@ -213,6 +205,14 @@ impl<'a> Deref for OperationRef<'a> {
         unsafe { transmute(self) }
     }
 }
+
+impl<'a> PartialEq for OperationRef<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { mlirOperationEqual(self.raw, other.raw) }
+    }
+}
+
+impl<'a> Eq for OperationRef<'a> {}
 
 impl<'a> Display for OperationRef<'a> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
@@ -258,7 +258,7 @@ mod tests {
         let operation =
             block.append_operation(Builder::new("foo", Location::unknown(&Context::new())).build());
 
-        assert_eq!(operation.block(), Some(*block));
+        assert_eq!(operation.block(), Some(*block.as_ref()));
     }
 
     #[test]

--- a/src/ir/operation.rs
+++ b/src/ir/operation.rs
@@ -258,7 +258,7 @@ mod tests {
         let operation =
             block.append_operation(Builder::new("foo", Location::unknown(&Context::new())).build());
 
-        assert_eq!(operation.block(), Some(*block.as_ref()));
+        assert_eq!(operation.block().as_deref(), Some(&block));
     }
 
     #[test]

--- a/src/ir/operation.rs
+++ b/src/ir/operation.rs
@@ -109,11 +109,6 @@ impl<'c> Operation<'c> {
         unsafe { mlirOperationDump(self.raw) }
     }
 
-    /// Clones an operation.
-    pub fn to_owned(&self) -> Operation {
-        unsafe { Operation::from_raw(mlirOperationClone(self.raw)) }
-    }
-
     pub(crate) unsafe fn from_raw(raw: MlirOperation) -> Self {
         Self {
             raw,
@@ -127,6 +122,12 @@ impl<'c> Operation<'c> {
         forget(self);
 
         operation
+    }
+}
+
+impl<'c> Clone for Operation<'c> {
+    fn clone(&self) -> Self {
+        unsafe { Operation::from_raw(mlirOperationClone(self.raw)) }
     }
 }
 
@@ -291,11 +292,11 @@ mod tests {
     }
 
     #[test]
-    fn to_owned() {
+    fn clone() {
         let context = Context::new();
         let operation = Builder::new("foo", Location::unknown(&context)).build();
 
-        operation.to_owned();
+        let _ = operation.clone();
     }
 
     #[test]

--- a/src/ir/operation/builder.rs
+++ b/src/ir/operation/builder.rs
@@ -1,6 +1,6 @@
 use crate::{
     context::Context,
-    ir::{Attribute, BlockRef, Identifier, Location, Region, Type, TypeLike, Value, ValueLike},
+    ir::{Attribute, Block, Identifier, Location, Region, Type, TypeLike, Value, ValueLike},
     string_ref::StringRef,
     utility::into_raw_array,
 };
@@ -78,7 +78,7 @@ impl<'c> Builder<'c> {
     /// Adds successor blocks.
     // TODO Fix this to ensure blocks are alive while they are referenced by the
     // operation.
-    pub fn add_successors(mut self, successors: &[BlockRef]) -> Self {
+    pub fn add_successors(mut self, successors: &[&Block<'c>]) -> Self {
         unsafe {
             mlirOperationStateAddSuccessors(
                 &mut self.raw,
@@ -156,7 +156,7 @@ mod tests {
         let context = Context::new();
 
         Builder::new("foo", Location::unknown(&context))
-            .add_successors(&[*Block::new(&[]).as_ref()])
+            .add_successors(&[&Block::new(&[])])
             .build();
     }
 

--- a/src/ir/operation/builder.rs
+++ b/src/ir/operation/builder.rs
@@ -156,7 +156,7 @@ mod tests {
         let context = Context::new();
 
         Builder::new("foo", Location::unknown(&context))
-            .add_successors(&[*Block::new(&[])])
+            .add_successors(&[*Block::new(&[]).as_ref()])
             .build();
     }
 

--- a/src/ir/operation/result.rs
+++ b/src/ir/operation/result.rs
@@ -76,6 +76,6 @@ mod tests {
         let r#type = Type::parse(&context, "index").unwrap();
         let block = Block::new(&[(r#type, Location::unknown(&context))]);
 
-        assert_eq!(block.argument(0).unwrap().owner(), *block);
+        assert_eq!(&*block.argument(0).unwrap().owner(), &block);
     }
 }

--- a/src/ir/region.rs
+++ b/src/ir/region.rs
@@ -4,67 +4,26 @@ use mlir_sys::{
     mlirRegionGetFirstBlock, mlirRegionInsertOwnedBlockAfter, mlirRegionInsertOwnedBlockBefore,
     MlirRegion,
 };
-use std::{marker::PhantomData, mem::forget, ops::Deref};
+use std::{
+    marker::PhantomData,
+    mem::{forget, transmute},
+    ops::Deref,
+};
 
 /// A region.
 #[derive(Debug)]
 pub struct Region {
-    r#ref: RegionRef<'static>,
+    raw: MlirRegion,
 }
 
 impl Region {
     /// Creates a region.
     pub fn new() -> Self {
         Self {
-            r#ref: unsafe { RegionRef::from_raw(mlirRegionCreate()) },
+            raw: unsafe { mlirRegionCreate() },
         }
     }
 
-    pub(crate) unsafe fn into_raw(self) -> mlir_sys::MlirRegion {
-        let region = self.raw;
-
-        forget(self);
-
-        region
-    }
-}
-
-impl Default for Region {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Drop for Region {
-    fn drop(&mut self) {
-        unsafe { mlirRegionDestroy(self.raw) }
-    }
-}
-
-impl PartialEq for Region {
-    fn eq(&self, other: &Self) -> bool {
-        self.r#ref == other.r#ref
-    }
-}
-
-impl Eq for Region {}
-
-impl Deref for Region {
-    type Target = RegionRef<'static>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.r#ref
-    }
-}
-
-/// A reference to a region.
-#[derive(Clone, Copy, Debug)]
-pub struct RegionRef<'a> {
-    raw: MlirRegion,
-    _region: PhantomData<&'a Region>,
-}
-
-impl<'a> RegionRef<'a> {
     /// Gets the first block in a region.
     pub fn first_block(&self) -> Option<BlockRef> {
         unsafe {
@@ -111,6 +70,49 @@ impl<'a> RegionRef<'a> {
         }
     }
 
+    pub(crate) unsafe fn into_raw(self) -> mlir_sys::MlirRegion {
+        let region = self.raw;
+
+        forget(self);
+
+        region
+    }
+}
+
+impl Default for Region {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for Region {
+    fn drop(&mut self) {
+        unsafe { mlirRegionDestroy(self.raw) }
+    }
+}
+
+impl PartialEq for Region {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { mlirRegionEqual(self.raw, other.raw) }
+    }
+}
+
+impl Eq for Region {}
+
+impl<'a> AsRef<RegionRef<'a>> for Region {
+    fn as_ref(&self) -> &RegionRef<'a> {
+        unsafe { transmute(self) }
+    }
+}
+
+/// A reference to a region.
+#[derive(Clone, Copy, Debug)]
+pub struct RegionRef<'a> {
+    raw: MlirRegion,
+    _region: PhantomData<&'a Region>,
+}
+
+impl<'a> RegionRef<'a> {
     pub(crate) unsafe fn from_raw(raw: MlirRegion) -> Self {
         Self {
             raw,
@@ -124,6 +126,14 @@ impl<'a> RegionRef<'a> {
         } else {
             Some(Self::from_raw(raw))
         }
+    }
+}
+
+impl<'a> Deref for RegionRef<'a> {
+    type Target = RegionRef<'static>;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { transmute(self) }
     }
 }
 

--- a/src/ir/region.rs
+++ b/src/ir/region.rs
@@ -99,12 +99,6 @@ impl PartialEq for Region {
 
 impl Eq for Region {}
 
-impl<'a> AsRef<RegionRef<'a>> for Region {
-    fn as_ref(&self) -> &RegionRef<'a> {
-        unsafe { transmute(self) }
-    }
-}
-
 /// A reference to a region.
 #[derive(Clone, Copy, Debug)]
 pub struct RegionRef<'a> {
@@ -130,7 +124,7 @@ impl<'a> RegionRef<'a> {
 }
 
 impl<'a> Deref for RegionRef<'a> {
-    type Target = RegionRef<'static>;
+    type Target = Region;
 
     fn deref(&self) -> &Self::Target {
         unsafe { transmute(self) }


### PR DESCRIPTION
The current impl of `Deref` is abuse.

Close #57.

# Todo

- [ ] ~~`Borrow` and `ToOwned` for `Operation`~~
- [ ] ~~`AsRef` for all~~
  - [x] `Block`
  - [ ] `Context`
  - [ ] `Operation`
  - [x] `Region`