### PR TITLE
Use dashmap instead of rwlock hashmap

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -12,6 +12,7 @@
     "canonicalizer",
     "cmpi",
     "codegen",
+    "dashmap",
     "dealloc",
     "detensorize",
     "elementwise",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +328,12 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
@@ -438,6 +457,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +480,7 @@ name = "melior"
 version = "0.8.2"
 dependencies = [
  "criterion",
+ "dashmap",
  "indoc",
  "insta",
  "melior-macro",
@@ -554,6 +584,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot_core"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +690,15 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -749,6 +801,12 @@ name = "similar"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "syn"

--- a/melior/Cargo.toml
+++ b/melior/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["mlir", "llvm"]
 
 [dependencies]
 criterion = "0.5.1"
+dashmap = "5.4.0"
 melior-macro = { version = "0.3", path = "../macro" }
 mlir-sys = "0.2"
 once_cell = "1"


### PR DESCRIPTION
fixes a TOCTOU race which made tests fail sometimes: https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use

dashmap is the current go-to concurrent hashmap: https://github.com/xacrimon/dashmap

I found this because i was getting issues when running the GEP tests, they worked if i ran them alone, but since cargo executes tests in paralel, you can notice the bug there.

The contains key could be invalid at the time of insertion, which could produce buggy results, because its not atomic.