### PR TITLE
Unsafe context/operation dereferences

### DIFF
--- a/melior/src/context.rs
+++ b/melior/src/context.rs
@@ -150,11 +150,15 @@ impl<'c> ContextRef<'c> {
     ///
     /// This function is different from `deref` because the correct lifetime is kept for the return
     /// type.
-    pub fn to_ref(&self) -> &'c Context {
+    ///
+    /// # Safety
+    ///
+    /// The returned reference is safe to use only in the lifetime scope of the context reference.
+    pub unsafe fn to_ref(&self) -> &'c Context {
         // As we can't deref ContextRef<'a> into `&'a Context`, we forcibly cast its
         // lifetime here to extend it from the lifetime of `ObjectRef<'a>` itself into
         // `'a`.
-        unsafe { transmute(self) }
+        transmute(self)
     }
 
     /// Creates a context reference from a raw object.

--- a/melior/src/context.rs
+++ b/melior/src/context.rs
@@ -140,12 +140,23 @@ impl Eq for Context {}
 
 /// A reference to a context.
 #[derive(Clone, Copy, Debug)]
-pub struct ContextRef<'a> {
+pub struct ContextRef<'c> {
     raw: MlirContext,
-    _reference: PhantomData<&'a Context>,
+    _reference: PhantomData<&'c Context>,
 }
 
-impl<'a> ContextRef<'a> {
+impl<'c> ContextRef<'c> {
+    /// Gets a context.
+    ///
+    /// This function is different from `deref` because the correct lifetime is kept for the return
+    /// type.
+    pub fn to_ref(&self) -> &'c Context {
+        // As we can't deref ContextRef<'a> into `&'a Context`, we forcibly cast its
+        // lifetime here to extend it from the lifetime of `ObjectRef<'a>` itself into
+        // `'a`.
+        unsafe { transmute(self) }
+    }
+
     /// Creates a context reference from a raw object.
     ///
     /// # Safety

--- a/melior/src/ir/operation.rs
+++ b/melior/src/ir/operation.rs
@@ -216,12 +216,20 @@ pub struct OperationRef<'a> {
 }
 
 impl<'a> OperationRef<'a> {
-    /// Gets a result at a position.
-    pub fn result(self, index: usize) -> Result<OperationResult<'a>, Error> {
+    /// Gets an operation.
+    ///
+    /// This function is different from `deref` because the correct lifetime is kept for the return
+    /// type.
+    pub fn as_operation(&self) -> &'a Operation<'a> {
         // As we can't deref OperationRef<'a> into `&'a Operation`, we forcibly cast its
         // lifetime here to extend it from the lifetime of `ObjectRef<'a>` itself into
         // `'a`.
-        unsafe { transmute(self.deref().result(index)) }
+        unsafe { transmute(self) }
+    }
+
+    /// Gets a result at a position.
+    pub fn result(self, index: usize) -> Result<OperationResult<'a>, Error> {
+        self.as_operation().result(index)
     }
 
     /// Converts an operation reference into a raw object.

--- a/melior/src/ir/operation.rs
+++ b/melior/src/ir/operation.rs
@@ -216,25 +216,29 @@ pub struct OperationRef<'a> {
 }
 
 impl<'a> OperationRef<'a> {
-    /// Gets an operation.
-    ///
-    /// This function is different from `deref` because the correct lifetime is kept for the return
-    /// type.
-    pub fn as_operation(&self) -> &'a Operation<'a> {
-        // As we can't deref OperationRef<'a> into `&'a Operation`, we forcibly cast its
-        // lifetime here to extend it from the lifetime of `ObjectRef<'a>` itself into
-        // `'a`.
-        unsafe { transmute(self) }
-    }
-
     /// Gets a result at a position.
     pub fn result(self, index: usize) -> Result<OperationResult<'a>, Error> {
-        self.as_operation().result(index)
+        unsafe { self.to_ref() }.result(index)
     }
 
     /// Converts an operation reference into a raw object.
     pub const fn to_raw(self) -> MlirOperation {
         self.raw
+    }
+
+    /// Gets an operation.
+    ///
+    /// This function is different from `deref` because the correct lifetime is kept for the return
+    /// type.
+    ///
+    /// # Safety
+    ///
+    /// The returned reference is safe to use only in the lifetime scope of the operation reference.
+    pub unsafe fn to_ref(&self) -> &'a Operation<'a> {
+        // As we can't deref OperationRef<'a> into `&'a Operation`, we forcibly cast its
+        // lifetime here to extend it from the lifetime of `ObjectRef<'a>` itself into
+        // `'a`.
+        transmute(self)
     }
 
     /// Creates an operation reference from a raw object.


### PR DESCRIPTION
- Should we adopt the original lifetime design of [Inkwell](https://thedan64.github.io/inkwell/inkwell/index.html)?
  - But then, we need to distinguish `Context` and `ContextRef` in function signatures, or create another trait like `ContextRefLike`.
  - Or, we can use `ContextRef` everywhere although it doesn't look Rust-ish...