### PR TITLE
External pass

### DIFF
--- a/melior/src/dialect/handle.rs
+++ b/melior/src/dialect/handle.rs
@@ -105,7 +105,8 @@ impl DialectHandle {
         Self { raw: handle }
     }
 
-    pub const unsafe fn to_raw(self) -> MlirDialectHandle {
+    /// Converts a dialect handle into a raw object.
+    pub const fn to_raw(self) -> MlirDialectHandle {
         self.raw
     }
 }

--- a/melior/src/dialect/handle.rs
+++ b/melior/src/dialect/handle.rs
@@ -104,6 +104,10 @@ impl DialectHandle {
     pub const unsafe fn from_raw(handle: MlirDialectHandle) -> Self {
         Self { raw: handle }
     }
+
+    pub const unsafe fn to_raw(self) -> MlirDialectHandle {
+        self.raw
+    }
 }
 
 #[cfg(test)]

--- a/melior/src/ir/type/id.rs
+++ b/melior/src/ir/type/id.rs
@@ -3,7 +3,10 @@
 mod allocator;
 
 pub use allocator::Allocator;
-use mlir_sys::{mlirTypeIDEqual, mlirTypeIDHashValue, MlirTypeID};
+use mlir_sys::{
+    mlirTypeIDAllocatorAllocateTypeID, mlirTypeIDAllocatorCreate, mlirTypeIDAllocatorDestroy,
+    mlirTypeIDEqual, mlirTypeIDHashValue, MlirTypeID,
+};
 use std::hash::{Hash, Hasher};
 
 /// A type ID.
@@ -26,11 +29,12 @@ impl TypeId {
         self.raw
     }
 
-    pub fn create<T>(t: &T) -> Self {
+    pub fn create() -> Self {
         unsafe {
-            Self::from_raw(mlir_sys::mlirTypeIDCreate(
-                std::ptr::addr_of!(t) as *mut std::ffi::c_void
-            ))
+            let allocator = mlirTypeIDAllocatorCreate();
+            let id = mlirTypeIDAllocatorAllocateTypeID(allocator);
+            mlirTypeIDAllocatorDestroy(allocator);
+            Self::from_raw(id)
         }
     }
 }

--- a/melior/src/ir/type/id.rs
+++ b/melior/src/ir/type/id.rs
@@ -21,6 +21,18 @@ impl TypeId {
     pub const unsafe fn from_raw(raw: MlirTypeID) -> Self {
         Self { raw }
     }
+
+    pub unsafe fn to_raw(self) -> MlirTypeID {
+        self.raw
+    }
+
+    pub fn create<T>(t: &T) -> Self {
+        unsafe {
+            Self::from_raw(mlir_sys::mlirTypeIDCreate(
+                std::ptr::addr_of!(t) as *mut std::ffi::c_void
+            ))
+        }
+    }
 }
 
 impl PartialEq for TypeId {

--- a/melior/src/pass.rs
+++ b/melior/src/pass.rs
@@ -32,7 +32,12 @@ impl Pass {
         }
     }
 
-    pub unsafe fn from_raw(raw: MlirPass) -> Self {
+    /// Creates a pass from a raw object.
+    ///
+    /// # Safety
+    ///
+    /// A raw object must be valid.
+    pub const unsafe fn from_raw(raw: MlirPass) -> Self {
         Self { raw }
     }
 

--- a/melior/src/pass.rs
+++ b/melior/src/pass.rs
@@ -2,6 +2,7 @@
 
 pub mod r#async;
 pub mod conversion;
+pub mod external;
 pub mod gpu;
 pub mod linalg;
 mod manager;
@@ -9,7 +10,9 @@ mod operation_manager;
 pub mod sparse_tensor;
 pub mod transform;
 
-pub use self::{manager::PassManager, operation_manager::OperationPassManager};
+pub use self::{
+    external::ExternalPass, manager::PassManager, operation_manager::OperationPassManager,
+};
 use mlir_sys::MlirPass;
 
 /// A pass.
@@ -27,6 +30,10 @@ impl Pass {
         Self {
             raw: unsafe { create_raw() },
         }
+    }
+
+    pub unsafe fn from_raw(raw: MlirPass) -> Self {
+        Self { raw }
     }
 
     /// Converts a pass into a raw object.

--- a/melior/src/pass.rs
+++ b/melior/src/pass.rs
@@ -11,7 +11,8 @@ pub mod sparse_tensor;
 pub mod transform;
 
 pub use self::{
-    external::ExternalPass, manager::PassManager, operation_manager::OperationPassManager,
+    external::create_external, external::ExternalPass, manager::PassManager,
+    operation_manager::OperationPassManager,
 };
 use mlir_sys::MlirPass;
 

--- a/melior/src/pass/external.rs
+++ b/melior/src/pass/external.rs
@@ -51,7 +51,15 @@ pub trait ExternalPass<'c>: Sized + Clone {
     fn construct(&mut self) {}
     fn destruct(&mut self) {}
     fn initialize(&mut self, context: ContextRef<'c>);
-    fn run(&mut self, operation: OperationRef);
+    fn run(&mut self, operation: OperationRef<'c, '_>);
+}
+
+impl<'c, F: Fn(OperationRef<'c, '_>) + Clone> ExternalPass<'c> for F {
+    fn initialize(&mut self, _context: ContextRef<'c>) {}
+
+    fn run(&mut self, operation: OperationRef<'c, '_>) {
+        self(operation)
+    }
 }
 
 pub fn create_external<'c, T: ExternalPass<'c>>(

--- a/melior/src/pass/external.rs
+++ b/melior/src/pass/external.rs
@@ -47,46 +47,43 @@ unsafe extern "C" fn callback_clone<'a, T: ExternalPass<'a>>(pass: *mut T) -> *m
     ))
 }
 
-pub trait ExternalPass<'a>: Sized + Clone {
-    fn create_external(self) -> Pass {
-        unsafe {
-            let dep_dialects = self.dependent_dialects();
-            let mut dep_dialects_raw: Vec<_> =
-                dep_dialects.into_iter().map(|d| d.to_raw()).collect();
-            let callbacks = mlir_sys::MlirExternalPassCallbacks {
-                construct: Some(std::mem::transmute(callback_construct::<Self> as *const ())),
-                destruct: Some(std::mem::transmute(callback_destruct::<Self> as *const ())),
-                initialize: Some(std::mem::transmute(
-                    callback_initialize::<Self> as *const (),
-                )),
-                run: Some(std::mem::transmute(callback_run::<Self> as *const ())),
-                clone: Some(std::mem::transmute(callback_clone::<Self> as *const ())),
-            };
-            let pass = Box::<Self>::into_raw(Box::new(self));
-            let pass_ref = pass.as_ref().expect("pass is still valid");
-            let raw_pass = mlir_sys::mlirCreateExternalPass(
-                TypeId::create().to_raw(),
-                pass_ref.name().to_raw(),
-                pass_ref.argument().to_raw(),
-                pass_ref.description().to_raw(),
-                pass_ref.op_name().to_raw(),
-                dep_dialects_raw.len() as isize,
-                dep_dialects_raw.as_mut_ptr(),
-                callbacks,
-                pass as *mut std::ffi::c_void,
-            );
-            Pass::from_raw(raw_pass)
-        }
-    }
-
-    fn name(&self) -> StringRef<'a>;
-    fn argument(&self) -> StringRef<'a>;
-    fn description(&self) -> StringRef<'a>;
-    fn op_name(&self) -> StringRef<'a>;
-    fn dependent_dialects(&self) -> Vec<DialectHandle>;
-
+pub trait ExternalPass<'c>: Sized + Clone {
     fn construct(&mut self) {}
     fn destruct(&mut self) {}
-    fn initialize(&mut self, context: ContextRef<'a>);
+    fn initialize(&mut self, context: ContextRef<'c>);
     fn run(&mut self, operation: OperationRef);
+}
+
+pub fn create_external<'c, T: ExternalPass<'c>>(
+    pass: T,
+    name: &str,
+    argument: &str,
+    description: &str,
+    op_name: &str,
+    dependent_dialects: &[DialectHandle],
+) -> Pass {
+    unsafe {
+        let mut dep_dialects_raw: Vec<_> =
+            dependent_dialects.into_iter().map(|d| d.to_raw()).collect();
+        let callbacks = mlir_sys::MlirExternalPassCallbacks {
+            construct: Some(std::mem::transmute(callback_construct::<T> as *const ())),
+            destruct: Some(std::mem::transmute(callback_destruct::<T> as *const ())),
+            initialize: Some(std::mem::transmute(callback_initialize::<T> as *const ())),
+            run: Some(std::mem::transmute(callback_run::<T> as *const ())),
+            clone: Some(std::mem::transmute(callback_clone::<T> as *const ())),
+        };
+        let pass_box = Box::<T>::into_raw(Box::new(pass));
+        let raw_pass = mlir_sys::mlirCreateExternalPass(
+            TypeId::create().to_raw(),
+            StringRef::from(name).to_raw(),
+            StringRef::from(argument).to_raw(),
+            StringRef::from(description).to_raw(),
+            StringRef::from(op_name).to_raw(),
+            dep_dialects_raw.len() as isize,
+            dep_dialects_raw.as_mut_ptr(),
+            callbacks,
+            pass_box as *mut std::ffi::c_void,
+        );
+        Pass::from_raw(raw_pass)
+    }
 }

--- a/melior/src/pass/external.rs
+++ b/melior/src/pass/external.rs
@@ -1,0 +1,93 @@
+use super::Pass;
+use crate::{
+    dialect::DialectHandle,
+    ir::{r#type::TypeId, OperationRef},
+    ContextRef, StringRef,
+};
+use mlir_sys::{MlirContext, MlirExternalPass, MlirLogicalResult, MlirOperation};
+
+unsafe extern "C" fn callback_construct<'a, T: ExternalPass<'a>>(pass: *mut T) {
+    pass.as_mut()
+        .expect("pass should be valid when called")
+        .construct();
+}
+
+unsafe extern "C" fn callback_destruct<'a, T: ExternalPass<'a>>(pass: *mut T) {
+    pass.as_mut()
+        .expect("pass should be valid when called")
+        .destruct();
+    std::ptr::drop_in_place(pass);
+}
+
+unsafe extern "C" fn callback_initialize<'a, T: ExternalPass<'a>>(
+    ctx: MlirContext,
+    pass: *mut T,
+) -> MlirLogicalResult {
+    pass.as_mut()
+        .expect("pass should be valid when called")
+        .initialize(ContextRef::from_raw(ctx));
+    return MlirLogicalResult { value: 1 };
+}
+
+unsafe extern "C" fn callback_run<'a, T: ExternalPass<'a>>(
+    op: MlirOperation,
+    _mlir_pass: MlirExternalPass,
+    pass: *mut T,
+) {
+    pass.as_mut()
+        .expect("pass should be valid when called")
+        .run(OperationRef::from_raw(op))
+}
+
+unsafe extern "C" fn callback_clone<'a, T: ExternalPass<'a>>(pass: *mut T) -> *mut T {
+    Box::<T>::into_raw(Box::new(
+        pass.as_mut()
+            .expect("pass should be valid when called")
+            .clone(),
+    ))
+}
+
+pub trait ExternalPass<'a>: Sized + Clone {
+    fn create_external(self) -> Pass {
+        unsafe {
+            let dep_dialects = self.dependent_dialects();
+            let mut dep_dialects_raw: Vec<_> =
+                dep_dialects.into_iter().map(|d| d.to_raw()).collect();
+            let callbacks = mlir_sys::MlirExternalPassCallbacks {
+                construct: Some(std::mem::transmute(callback_construct::<Self> as *const ())),
+                destruct: Some(std::mem::transmute(callback_destruct::<Self> as *const ())),
+                initialize: Some(std::mem::transmute(
+                    callback_initialize::<Self> as *const (),
+                )),
+                run: Some(std::mem::transmute(callback_run::<Self> as *const ())),
+                clone: Some(std::mem::transmute(callback_clone::<Self> as *const ())),
+            };
+            let pass = Box::<Self>::into_raw(Box::new(self));
+            let pass_ref = pass.as_ref().expect("pass is still valid");
+            let raw_pass = mlir_sys::mlirCreateExternalPass(
+                pass_ref.type_id().to_raw(),
+                pass_ref.name().to_raw(),
+                pass_ref.argument().to_raw(),
+                pass_ref.description().to_raw(),
+                pass_ref.op_name().to_raw(),
+                dep_dialects_raw.len() as isize,
+                dep_dialects_raw.as_mut_ptr(),
+                callbacks,
+                pass as *mut std::ffi::c_void,
+            );
+            Pass::from_raw(raw_pass)
+        }
+    }
+
+    fn type_id(&self) -> TypeId;
+    fn name(&self) -> StringRef<'a>;
+    fn argument(&self) -> StringRef<'a>;
+    fn description(&self) -> StringRef<'a>;
+    fn op_name(&self) -> StringRef<'a>;
+    fn dependent_dialects(&self) -> Vec<DialectHandle>;
+
+    fn construct(&mut self) {}
+    fn destruct(&mut self) {}
+    fn initialize(&mut self, context: ContextRef<'a>);
+    fn run(&mut self, operation: OperationRef);
+}

--- a/melior/src/pass/external.rs
+++ b/melior/src/pass/external.rs
@@ -165,7 +165,7 @@ mod tests {
         ir::{
             attribute::{StringAttribute, TypeAttribute},
             r#type::FunctionType,
-            Block, Location, Module, Region,
+            Block, Identifier, Location, Module, Region,
         },
         pass::PassManager,
         test::create_test_context,
@@ -226,6 +226,17 @@ mod tests {
                 assert_eq!(self.value, 20);
                 self.value = 30;
                 assert!(operation.verify());
+                assert!(
+                    operation
+                        .region(0)
+                        .expect("module has a body")
+                        .first_block()
+                        .expect("module has a body")
+                        .first_operation()
+                        .expect("body has a function")
+                        .name()
+                        == Identifier::new(&operation.context(), "func.func")
+                );
             }
         }
 
@@ -265,6 +276,17 @@ mod tests {
         pass_manager.add_pass(create_external(
             |operation: OperationRef| {
                 assert!(operation.verify());
+                assert!(
+                    operation
+                        .region(0)
+                        .expect("module has a body")
+                        .first_block()
+                        .expect("module has a body")
+                        .first_operation()
+                        .expect("body has a function")
+                        .name()
+                        == Identifier::new(&operation.context(), "func.func")
+                );
             },
             TypeId::create(&TEST_FN_PASS),
             "test closure",

--- a/melior/src/pass/external.rs
+++ b/melior/src/pass/external.rs
@@ -65,7 +65,7 @@ pub trait ExternalPass<'a>: Sized + Clone {
             let pass = Box::<Self>::into_raw(Box::new(self));
             let pass_ref = pass.as_ref().expect("pass is still valid");
             let raw_pass = mlir_sys::mlirCreateExternalPass(
-                pass_ref.type_id().to_raw(),
+                TypeId::create().to_raw(),
                 pass_ref.name().to_raw(),
                 pass_ref.argument().to_raw(),
                 pass_ref.description().to_raw(),
@@ -79,7 +79,6 @@ pub trait ExternalPass<'a>: Sized + Clone {
         }
     }
 
-    fn type_id(&self) -> TypeId;
     fn name(&self) -> StringRef<'a>;
     fn argument(&self) -> StringRef<'a>;
     fn description(&self) -> StringRef<'a>;


### PR DESCRIPTION
This PR implements support for the external pass API, enabling the creation of MLIR passes in Rust. It's still a bit rough on the edges, this is an early draft.

The main idea is as follows:
- Users of `melior` create a struct and implement the `ExternalPass` trait.
- When calling `create_external` on this struct, we use the external pass API to create a pass on the MLIR side.
  - Using generic functions, callback functions are generated for this struct and passed to MLIR.
  - Ownership of the Rust pass struct is conceptually moved to MLIR as a pointer to this struct is passed as `userData`, hence `Box::into_raw` is used.
- When the callbacks are called, we cast the `userData` pointer to the appropriate Rust struct and call a method of the `ExternalPass` trait.
- When MLIR decides to destruct the C++ counterpart of this pass, we make sure to clean up our struct (manually `drop_in_place`), since it won't be freed by MLIR, and ownership is no longer tracked by Rust after leaking to `Box`.

The following code snippet illustrates how this can be used:

```rust
#[repr(align(8))]
struct TestType(u8);

static TEST_TYPE: TestType = TestType(0);

#[derive(Clone, Debug)]
struct TestPass {
    value: i32,
}

impl<'a> ExternalPass<'a> for TestPass {
    fn name(&self) -> StringRef<'a> {
        StringRef::from("test pass")
    }

    fn argument(&self) -> StringRef<'a> {
        StringRef::from("test argument")
    }

    fn description(&self) -> StringRef<'a> {
        StringRef::from("a test pass")
    }

    fn op_name(&self) -> StringRef<'a> {
        StringRef::from("")
    }

    fn dependent_dialects(&self) -> Vec<melior::dialect::DialectHandle> {
        vec![]
    }

    fn type_id(&self) -> TypeId {
        TypeId::create(&TEST_TYPE)
    }

    fn construct(&mut self) {
        println!("Constructed pass!");
    }

    fn initialize(&mut self, context: ContextRef<'_>) {
        println!("Initialize called!");
    }

    fn run(&mut self, operation: OperationRef<'_, '_>) {
        println!("Running test pass!");
        operation.dump();
    }
}

fn main() {
    let registry = DialectRegistry::new();
    register_all_dialects(&registry);

    let context = Context::new();
    context.append_dialect_registry(&registry);
    context.load_all_available_dialects();

    let location = Location::unknown(&context);
    let mut module = Module::new(location);

    let index_type = Type::index(&context);

    module.body().append_operation(func::func(
        &context,
        StringAttribute::new(&context, "add"),
        TypeAttribute::new(
            FunctionType::new(&context, &[index_type, index_type], &[index_type]).into(),
        ),
        {
            let block = Block::new(&[(index_type, location), (index_type, location)]);

            let sum = block.append_operation(arith::addi(
                block.argument(0).unwrap().into(),
                block.argument(1).unwrap().into(),
                location,
            ));

            block.append_operation(func::r#return(&[sum.result(0).unwrap().into()], location));

            let region = Region::new();
            region.append_block(block);
            region
        },
        &[],
        location,
    ));

    let pass_manager = PassManager::new(&context);

    let test_pass = TestPass { value: 10 };
    pass_manager.add_pass(test_pass.create_external());
    pass_manager.run(&mut module).unwrap();

}

```

Things that still need to be done:

- [ ] Write tests
- [ ] Write documentation with example of usage
- [ ] Make it a bit more ergonomic to use (e.g. the `TypeId` is still a bit awkward, support for `Fn` could be useful)