### PR TITLE
Additional getters and setters for operation and builder

### DIFF
--- a/melior/src/error.rs
+++ b/melior/src/error.rs
@@ -15,6 +15,7 @@ pub enum Error {
     },
     InvokeFunction,
     OperationResultExpected(String),
+    OperationAttributeExpected(String),
     PositionOutOfBounds {
         name: &'static str,
         value: String,
@@ -42,6 +43,9 @@ impl Display for Error {
             Self::InvokeFunction => write!(formatter, "failed to invoke JIT-compiled function"),
             Self::OperationResultExpected(value) => {
                 write!(formatter, "operation result expected: {value}")
+            }
+            Self::OperationAttributeExpected(value) => {
+                write!(formatter, "attribute {value} expected")
             }
             Self::ParsePassPipeline(message) => {
                 write!(formatter, "failed to parse pass pipeline:\n{}", message)

--- a/melior/src/ir/operation.rs
+++ b/melior/src/ir/operation.rs
@@ -165,7 +165,7 @@ impl<'c> Operation<'c> {
         }
     }
 
-    /// Gets all successorss.
+    /// Gets all successors.
     pub fn successors(&self) -> impl Iterator<Item = BlockRef<'c, '_>> {
         (0..self.successor_count())
             .map(|index| self.successor(index).expect("valid successor index"))

--- a/melior/src/ir/operation.rs
+++ b/melior/src/ir/operation.rs
@@ -196,7 +196,7 @@ impl<'c> Operation<'c> {
     }
 
     /// Gets all attributes.
-    pub fn attributes(&'c self) -> impl Iterator<Item = (Identifier<'c>, Attribute<'c>)> {
+    pub fn attributes(&self) -> impl Iterator<Item = (Identifier<'c>, Attribute<'c>)> + '_ {
         (0..self.attribute_count())
             .map(|index| self.attribute_at(index).expect("valid attribute index"))
     }

--- a/melior/src/ir/operation/builder.rs
+++ b/melior/src/ir/operation/builder.rs
@@ -10,7 +10,7 @@ use mlir_sys::{
     mlirOperationStateAddSuccessors, mlirOperationStateEnableResultTypeInference,
     mlirOperationStateGet, MlirOperationState,
 };
-use std::marker::PhantomData;
+use std::{marker::PhantomData, mem::forget};
 
 /// An operation builder.
 pub struct OperationBuilder<'c> {
@@ -29,6 +29,12 @@ impl<'c> OperationBuilder<'c> {
         }
     }
 
+    /// Adds a single result.
+    pub fn add_result(mut self, result: &Type<'c>) -> Self {
+        unsafe { mlirOperationStateAddResults(&mut self.raw, 1, result as *const _ as *const _) }
+        self
+    }
+
     /// Adds results.
     pub fn add_results(mut self, results: &[Type<'c>]) -> Self {
         unsafe {
@@ -38,6 +44,13 @@ impl<'c> OperationBuilder<'c> {
                 results as *const _ as *const _,
             )
         }
+
+        self
+    }
+
+    /// Adds a single operand.
+    pub fn add_operand(mut self, operand: &Value<'c, '_>) -> Self {
+        unsafe { mlirOperationStateAddOperands(&mut self.raw, 1, operand as *const _ as *const _) }
 
         self
     }
@@ -55,6 +68,16 @@ impl<'c> OperationBuilder<'c> {
         self
     }
 
+    /// Adds a single region.
+    pub fn add_region(mut self, region: Region<'c>) -> Self {
+        unsafe {
+            mlirOperationStateAddOwnedRegions(&mut self.raw, 1, &region as *const _ as *const _)
+        }
+        forget(region);
+
+        self
+    }
+
     /// Adds regions.
     pub fn add_regions(mut self, regions: Vec<Region<'c>>) -> Self {
         unsafe {
@@ -63,6 +86,15 @@ impl<'c> OperationBuilder<'c> {
                 regions.len() as isize,
                 regions.leak().as_ptr() as *const _ as *const _,
             )
+        }
+
+        self
+    }
+
+    /// Adds a single successor block.
+    pub fn add_successor(mut self, successor: &Block<'c>) -> Self {
+        unsafe {
+            mlirOperationStateAddSuccessors(&mut self.raw, 1, &successor as *const _ as *const _)
         }
 
         self
@@ -82,6 +114,23 @@ impl<'c> OperationBuilder<'c> {
                     .map(|block| block.to_raw())
                     .collect::<Vec<_>>()
                     .as_ptr() as *const _,
+            )
+        }
+
+        self
+    }
+
+    /// Adds a single attribute.
+    pub fn add_attribute(
+        mut self,
+        name: &Identifier<'c>,
+        attribute: &impl AttributeLike<'c>,
+    ) -> Self {
+        unsafe {
+            mlirOperationStateAddAttributes(
+                &mut self.raw,
+                1,
+                &mlirNamedAttributeGet(name.to_raw(), attribute.to_raw()) as *const _,
             )
         }
 
@@ -138,12 +187,62 @@ mod tests {
     }
 
     #[test]
+    fn add_operand() {
+        let context = create_test_context();
+        context.set_allow_unregistered_dialects(true);
+
+        let location = Location::unknown(&context);
+        let r#type = Type::index(&context);
+        let block = Block::new(&[(r#type, location)]);
+        let argument = block.argument(0).unwrap().into();
+
+        OperationBuilder::new("foo", Location::unknown(&context))
+            .add_operand(&argument)
+            .build();
+    }
+
+    #[test]
+    fn add_operands() {
+        let context = create_test_context();
+        context.set_allow_unregistered_dialects(true);
+
+        let location = Location::unknown(&context);
+        let r#type = Type::index(&context);
+        let block = Block::new(&[(r#type, location)]);
+        let argument = block.argument(0).unwrap().into();
+
+        OperationBuilder::new("foo", Location::unknown(&context))
+            .add_operands(&[argument])
+            .build();
+    }
+
+    #[test]
+    fn add_result() {
+        let context = create_test_context();
+        context.set_allow_unregistered_dialects(true);
+
+        OperationBuilder::new("foo", Location::unknown(&context))
+            .add_result(&Type::parse(&context, "i1").unwrap())
+            .build();
+    }
+
+    #[test]
     fn add_results() {
         let context = create_test_context();
         context.set_allow_unregistered_dialects(true);
 
         OperationBuilder::new("foo", Location::unknown(&context))
             .add_results(&[Type::parse(&context, "i1").unwrap()])
+            .build();
+    }
+
+    #[test]
+    fn add_region() {
+        let context = create_test_context();
+        context.set_allow_unregistered_dialects(true);
+
+        OperationBuilder::new("foo", Location::unknown(&context))
+            .add_region(Region::new())
             .build();
     }
 
@@ -158,12 +257,35 @@ mod tests {
     }
 
     #[test]
+    fn add_successor() {
+        let context = create_test_context();
+        context.set_allow_unregistered_dialects(true);
+
+        OperationBuilder::new("foo", Location::unknown(&context))
+            .add_successor(&Block::new(&[]))
+            .build();
+    }
+
+    #[test]
     fn add_successors() {
         let context = create_test_context();
         context.set_allow_unregistered_dialects(true);
 
         OperationBuilder::new("foo", Location::unknown(&context))
             .add_successors(&[&Block::new(&[])])
+            .build();
+    }
+
+    #[test]
+    fn add_attribute() {
+        let context = create_test_context();
+        context.set_allow_unregistered_dialects(true);
+
+        OperationBuilder::new("foo", Location::unknown(&context))
+            .add_attribute(
+                &Identifier::new(&context, "foo"),
+                &Attribute::parse(&context, "unit").unwrap(),
+            )
             .build();
     }
 

--- a/melior/src/ir/operation/builder.rs
+++ b/melior/src/ir/operation/builder.rs
@@ -121,11 +121,7 @@ impl<'c> OperationBuilder<'c> {
     }
 
     /// Adds a single attribute.
-    pub fn add_attribute(
-        mut self,
-        name: &Identifier<'c>,
-        attribute: &impl AttributeLike<'c>,
-    ) -> Self {
+    pub fn add_attribute(mut self, name: &Identifier<'c>, attribute: &Attribute<'c>) -> Self {
         unsafe {
             mlirOperationStateAddAttributes(
                 &mut self.raw,


### PR DESCRIPTION
Added additional getters and setters for `Operation` such that you can get operands, results and attributes, and modify attributes. Most of these new functions are not strictly necessary, but they can be more convenient than the existing functions.

I'm using the `AttributeLike` trait such that any attribute-like type can be used. I wonder if we should also use this as generic return type for `Operation::attribute`?

I also created a `OperationOperand` type, but currently it is simply and alias for `Value`. Should `OperationOperand` be a more complex type like `OperationResult`, or should I remove `OperationOperand` and replace all its occurences with `Value`?

If I'm not mistaken, operands, results, successors and attributes can be borrowed by the builder, while ownership of regions is moved to MLIR (hence the call to `forget`).

And one last thing: should I use `&str` instead of `impl AsRef<str>`, or is it fine like this?

Please let me know if there's anything else I should change.