### PR TITLE
Remove panics from macro code

### DIFF
--- a/macro/src/dialect/error.rs
+++ b/macro/src/dialect/error.rs
@@ -12,6 +12,7 @@ use tblgen::{
 #[derive(Debug)]
 pub enum Error {
     ExpectedSuperClass(SourceError<ExpectedSuperClassError>),
+    InvalidTrait(SourceError<InvalidTraitError>),
     Io(io::Error),
     ParseError,
     Syn(syn::Error),
@@ -24,6 +25,7 @@ impl Error {
         match self {
             Self::TableGen(error) => error.add_source_info(info).into(),
             Self::ExpectedSuperClass(error) => error.add_source_info(info).into(),
+            Self::InvalidTrait(error) => error.add_source_info(info).into(),
             Self::Io(_) | Self::ParseError | Self::Syn(_) | Self::Utf8(_) => self,
         }
     }
@@ -33,6 +35,7 @@ impl Display for Error {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match self {
             Self::ExpectedSuperClass(error) => write!(formatter, "invalid ODS input: {error}"),
+            Self::InvalidTrait(error) => write!(formatter, "invalid ODS input: {error}"),
             Self::Io(error) => write!(formatter, "{error}"),
             Self::ParseError => write!(formatter, "error parsing TableGen source"),
             Self::Syn(error) => write!(formatter, "failed to parse macro input: {error}"),
@@ -47,6 +50,12 @@ impl error::Error for Error {}
 impl From<SourceError<ExpectedSuperClassError>> for Error {
     fn from(error: SourceError<ExpectedSuperClassError>) -> Self {
         Self::ExpectedSuperClass(error)
+    }
+}
+
+impl From<SourceError<InvalidTraitError>> for Error {
+    fn from(error: SourceError<InvalidTraitError>) -> Self {
+        Self::InvalidTrait(error)
     }
 }
 
@@ -88,3 +97,14 @@ impl Display for ExpectedSuperClassError {
 }
 
 impl error::Error for ExpectedSuperClassError {}
+
+#[derive(Debug)]
+pub struct InvalidTraitError;
+
+impl Display for InvalidTraitError {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "record is not a supported trait")
+    }
+}
+
+impl error::Error for InvalidTraitError {}

--- a/macro/src/dialect/operation.rs
+++ b/macro/src/dialect/operation.rs
@@ -468,13 +468,11 @@ impl<'a> Operation<'a> {
             .collect::<Result<Vec<_>, _>>()?;
 
         let name = def.name()?;
-        let class_name = if !name.contains('_') {
-            // Class name with a leading underscore and without dialect prefix
-            name
-        } else if !name.starts_with('_') {
-            // Class name without dialect prefix
-            let mut split = name.split('_');
-            split.nth(1).expect("string contains separator '_'")
+        let class_name = if name.contains('_') && !name.starts_with('_') {
+            // Trim dialect prefix from name
+            name.split('_')
+                .nth(1)
+                .expect("string contains separator '_'")
         } else {
             name
         };

--- a/macro/src/dialect/operation.rs
+++ b/macro/src/dialect/operation.rs
@@ -230,8 +230,9 @@ impl<'a> OperationField<'a> {
 
 #[derive(Debug, Clone)]
 pub struct Operation<'a> {
-    def: Record<'a>,
     pub(crate) dialect: Record<'a>,
+    pub(crate) short_name: &'a str,
+    pub(crate) full_name: String,
     pub(crate) class_name: &'a str,
     pub(crate) fields: Vec<OperationField<'a>>,
     pub(crate) can_infer_type: bool,
@@ -256,7 +257,7 @@ impl<'a> Operation<'a> {
                     if trait_def.subclass_of("Interface") {
                         work_list.push(trait_def.list_value("baseInterfaces")?);
                     }
-                    traits.push(Trait::new(trait_def))
+                    traits.push(Trait::new(trait_def)?)
                 }
             }
         }
@@ -466,15 +467,14 @@ impl<'a> Operation<'a> {
             .chain(derived_attrs)
             .collect::<Result<Vec<_>, _>>()?;
 
-        let name = def.name().unwrap();
+        let name = def.name()?;
         let class_name = if !name.contains('_') {
             // Class name with a leading underscore and without dialect prefix
             name
         } else if !name.starts_with('_') {
             // Class name without dialect prefix
             let mut split = name.split('_');
-            split.next();
-            split.next().unwrap()
+            split.nth(1).expect("string contains separator '_'")
         } else {
             name
         };
@@ -486,8 +486,15 @@ impl<'a> Operation<'a> {
                 || t.has_name("::mlir::InferTypeOpInterface::Trait") && regions_dag.num_args() == 0
         });
 
-        let short_name = def.string_value("opName").expect("operation has name");
-        let summary = def.str_value("summary").unwrap_or(&short_name);
+        let short_name = def.str_value("opName")?;
+        let dialect_name = dialect.string_value("name")?;
+        let full_name = if !dialect_name.is_empty() {
+            format!("{}.{}", dialect_name, short_name)
+        } else {
+            short_name.into()
+        };
+
+        let summary = def.str_value("summary").unwrap_or(short_name);
         let description = def.str_value("description").unwrap_or("");
 
         let summary = if !summary.is_empty() {
@@ -503,8 +510,9 @@ impl<'a> Operation<'a> {
         let description = unindent::unindent(description);
 
         Ok(Self {
-            def,
             dialect,
+            short_name,
+            full_name,
             class_name,
             fields,
             can_infer_type,
@@ -512,29 +520,12 @@ impl<'a> Operation<'a> {
             description,
         })
     }
-
-    fn short_name(&self) -> String {
-        self.def.string_value("opName").expect("operation has name")
-    }
-
-    fn name(&self) -> String {
-        let op_name = self.def.string_value("opName").expect("operation has name");
-        let dialect_name = self
-            .dialect
-            .string_value("name")
-            .expect("dialect name is string");
-        if !dialect_name.is_empty() {
-            format!("{}.{}", dialect_name, op_name)
-        } else {
-            op_name
-        }
-    }
 }
 
 impl<'a> ToTokens for Operation<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let class_name = format_ident!("{}", &self.class_name);
-        let name = self.name();
+        let name = &self.full_name;
         let accessors = self.fields.iter().map(|field| field.accessors());
         let builder = OperationBuilder::new(self);
         let builder_tokens = builder.builder();

--- a/macro/src/dialect/operation/builder.rs
+++ b/macro/src/dialect/operation/builder.rs
@@ -205,7 +205,7 @@ impl<'o, 'c> OperationBuilder<'o, 'c> {
         let methods = self.methods(field_names.as_slice(), phantoms.as_slice());
 
         let new = {
-            let name_str = self.operation.name();
+            let name_str = &self.operation.full_name;
             let iter_all_no = self.type_state.iter_all_no();
             let phantoms = phantoms.clone();
             quote! {
@@ -274,7 +274,7 @@ impl<'o, 'c> OperationBuilder<'o, 'c> {
 
     pub fn default_constructor(&self) -> TokenStream {
         let class_name = format_ident!("{}", &self.operation.class_name);
-        let name = sanitize_name_snake(&self.operation.short_name());
+        let name = sanitize_name_snake(self.operation.short_name);
         let mut args = self
             .operation
             .fields


### PR DESCRIPTION
Replaced calls to methods that may panic (`unwrap` and `expect`) with `Result`s, and did some minor refactoring.