### PR TITLE
Return `Result` in accessors instead of panic

### DIFF
--- a/macro/src/dialect/operation.rs
+++ b/macro/src/dialect/operation.rs
@@ -76,10 +76,11 @@ impl<'a> OperationField<'a> {
         let (param_type, return_type) = {
             if ac.is_unit() {
                 (quote! { bool }, quote! { bool })
-            } else if ac.is_optional() {
-                (quote! { #kind_type<'c> }, quote! { Option<#kind_type<'c>> })
             } else {
-                (quote! { #kind_type<'c> }, quote! { #kind_type<'c> })
+                (
+                    quote! { #kind_type<'c> },
+                    quote! { Result<#kind_type<'c>, ::melior::Error> },
+                )
             }
         };
         let sanitized = sanitize_name_snake(name);
@@ -108,7 +109,7 @@ impl<'a> OperationField<'a> {
             } else {
                 (
                     quote! { ::melior::ir::Region<'c> },
-                    quote! { ::melior::ir::RegionRef<'c, '_> },
+                    quote! { Result<::melior::ir::RegionRef<'c, '_>, ::melior::Error> },
                 )
             }
         };
@@ -142,7 +143,7 @@ impl<'a> OperationField<'a> {
             } else {
                 (
                     quote! { &::melior::ir::Block<'c> },
-                    quote! { ::melior::ir::BlockRef<'c, '_> },
+                    quote! { Result<::melior::ir::BlockRef<'c, '_>, ::melior::Error> },
                 )
             }
         };
@@ -201,16 +202,19 @@ impl<'a> OperationField<'a> {
                 if tc.is_optional() {
                     (
                         quote! { #param_kind_type },
-                        quote! { Option<#return_kind_type> },
+                        quote! { Result<#return_kind_type, ::melior::Error> },
                     )
                 } else {
                     (
                         quote! { &[#param_kind_type] },
-                        quote! { impl Iterator<Item = #return_kind_type> },
+                        quote! { Result<impl Iterator<Item = #return_kind_type>, ::melior::Error> },
                     )
                 }
             } else {
-                (param_kind_type, return_kind_type)
+                (
+                    param_kind_type,
+                    quote!(Result<#return_kind_type, ::melior::Error>),
+                )
             }
         };
 

--- a/macro/src/dialect/operation.rs
+++ b/macro/src/dialect/operation.rs
@@ -207,7 +207,11 @@ impl<'a> OperationField<'a> {
                 } else {
                     (
                         quote! { &[#param_kind_type] },
-                        quote! { Result<impl Iterator<Item = #return_kind_type>, ::melior::Error> },
+                        if let VariadicKind::AttrSized {} = variadic_info {
+                            quote! { Result<impl Iterator<Item = #return_kind_type>, ::melior::Error> }
+                        } else {
+                            quote! { impl Iterator<Item = #return_kind_type> }
+                        },
                     )
                 }
             } else {

--- a/macro/src/dialect/operation/accessors.rs
+++ b/macro/src/dialect/operation/accessors.rs
@@ -164,9 +164,10 @@ impl<'a> OperationField<'a> {
                     quote! { self.operation.attribute(#name).is_some() }
                 } else {
                     quote! {
-                        Ok(self.operation
+                        self.operation
                             .attribute(#name)?
-                            .try_into()?)
+                            .try_into()
+                            .map_err(::melior::Error::from)
                     }
                 })
             }

--- a/macro/src/dialect/operation/accessors.rs
+++ b/macro/src/dialect/operation/accessors.rs
@@ -49,7 +49,7 @@ impl<'a> OperationField<'a> {
                                 // singular elements from the number of elements.
                                 quote! {
                                   let group_length = self.operation.#count() - #len + 1;
-                                  Ok(self.operation.#plural().skip(#index).take(group_length))
+                                  self.operation.#plural().skip(#index).take(group_length)
                                 }
                             }
                         } else if *seen_variable_length {
@@ -78,7 +78,7 @@ impl<'a> OperationField<'a> {
                         };
                         let get_elements = if constraint.is_variable_length() {
                             quote! {
-                                Ok(self.operation.#plural().skip(start).take(group_len))
+                                self.operation.#plural().skip(start).take(group_len)
                             }
                         } else {
                             quote! {

--- a/macro/src/dialect/operation/accessors.rs
+++ b/macro/src/dialect/operation/accessors.rs
@@ -19,6 +19,12 @@ impl<'a> OperationField<'a> {
                     .variadic_info
                     .as_ref()
                     .expect("operands and results need variadic info");
+                let error_variant = match &self.kind {
+                    FieldKind::Operand(_) => quote!(OperandNotFound),
+                    FieldKind::Result(_) => quote!(ResultNotFound),
+                    _ => unreachable!(),
+                };
+                let name = self.name;
 
                 Some(match variadic_kind {
                     VariadicKind::Simple {
@@ -32,9 +38,9 @@ impl<'a> OperationField<'a> {
                                 // elements.
                                 quote! {
                                   if self.operation.#count() < #len {
-                                    None
+                                    Err(::melior::Error::#error_variant(#name))
                                   } else {
-                                    self.operation.#kind_ident(#index).ok()
+                                    self.operation.#kind_ident(#index)
                                   }
                                 }
                             } else {
@@ -43,22 +49,20 @@ impl<'a> OperationField<'a> {
                                 // singular elements from the number of elements.
                                 quote! {
                                   let group_length = self.operation.#count() - #len + 1;
-                                  self.operation.#plural().skip(#index).take(group_length)
+                                  Ok(self.operation.#plural().skip(#index).take(group_length))
                                 }
                             }
                         } else if *seen_variable_length {
                             // Single element after variable length group
                             // Compute the length of that variable group and take the next element
-                            let error = format!("operation should have this {}", kind);
                             quote! {
                                 let group_length = self.operation.#count() - #len + 1;
-                                self.operation.#kind_ident(#index + group_length - 1).expect(#error)
+                                self.operation.#kind_ident(#index + group_length - 1)
                             }
                         } else {
                             // All elements so far are singular
-                            let error = format!("operation should have this {}", kind);
                             quote! {
-                                self.operation.#kind_ident(#index).expect(#error)
+                                self.operation.#kind_ident(#index)
                             }
                         }
                     }
@@ -67,7 +71,6 @@ impl<'a> OperationField<'a> {
                         num_preceding_simple,
                         num_preceding_variadic,
                     } => {
-                        let error = format!("operation should have this {}", kind);
                         let compute_start_length = quote! {
                             let total_var_len = self.operation.#count() - #num_variable_length + 1;
                             let group_len = total_var_len / #num_variable_length;
@@ -75,51 +78,46 @@ impl<'a> OperationField<'a> {
                         };
                         let get_elements = if constraint.is_variable_length() {
                             quote! {
-                                self.operation.#plural().skip(start).take(group_len)
+                                Ok(self.operation.#plural().skip(start).take(group_len))
                             }
                         } else {
                             quote! {
-                                self.operation.#kind_ident(start).expect(#error)
+                                self.operation.#kind_ident(start)
                             }
                         };
 
                         quote! { #compute_start_length #get_elements }
                     }
                     VariadicKind::AttrSized {} => {
-                        let error = format!("operation should have this {}", kind);
                         let attribute_name = format!("{}_segment_sizes", kind);
-                        let attribute_missing_error =
-                            format!("operation has {} attribute", attribute_name);
                         let compute_start_length = quote! {
                             let attribute =
                                 ::melior::ir::attribute::DenseI32ArrayAttribute::<'c>::try_from(
                                     self.operation
-                                        .attribute(#attribute_name)
-                                        .expect(#attribute_missing_error)
-                                ).expect("is a DenseI32ArrayAttribute");
+                                        .attribute(#attribute_name)?
+                                )?;
                             let start = (0..#index)
-                                .map(|index| attribute.element(index)
-                                .expect("has segment size"))
+                                .map(|index| attribute.element(index))
+                                .collect::<Result<Vec<_>, _>>()?
+                                .into_iter()
                                 .sum::<i32>() as usize;
-                            let group_len = attribute
-                                .element(#index)
-                                .expect("has segment size") as usize;
+                            let group_len = attribute.element(#index)? as usize;
                         };
                         let get_elements = if !constraint.is_variable_length() {
                             quote! {
-                                self.operation.#kind_ident(start).expect(#error)
+                                self.operation.#kind_ident(start)
                             }
                         } else if constraint.is_optional() {
                             quote! {
                                 if group_len == 0 {
-                                    None
+                                    Err(::melior::Error::#error_variant(#name))
                                 } else {
-                                    self.operation.#kind_ident(start).ok()
+                                    self.operation.#kind_ident(start)
                                 }
                             }
                         } else {
                             quote! {
-                                self.operation.#plural().skip(start).take(group_len)
+                                Ok(self.operation.#plural().skip(start).take(group_len))
                             }
                         };
 
@@ -140,7 +138,7 @@ impl<'a> OperationField<'a> {
                     }
                 } else {
                     quote! {
-                        self.operation.successor(#index).expect("operation should have this successor")
+                        self.operation.successor(#index)
                     }
                 })
             }
@@ -155,30 +153,20 @@ impl<'a> OperationField<'a> {
                     }
                 } else {
                     quote! {
-                        self.operation.region(#index).expect("operation should have this region")
+                        self.operation.region(#index)
                     }
                 })
             }
             FieldKind::Attribute(constraint) => {
                 let name = &self.name;
-                let attribute_error = format!("operation should have attribute {}", name);
-                let type_error = format!("{} should be a {}", name, constraint.storage_type());
 
                 Some(if constraint.is_unit() {
                     quote! { self.operation.attribute(#name).is_some() }
-                } else if constraint.is_optional() {
-                    quote! {
-                        self.operation
-                            .attribute(#name)
-                            .map(|attribute| attribute.try_into().expect(#type_error))
-                    }
                 } else {
                     quote! {
-                        self.operation
-                            .attribute(#name)
-                            .expect(#attribute_error)
-                            .try_into()
-                            .expect(#type_error)
+                        Ok(self.operation
+                            .attribute(#name)?
+                            .try_into()?)
                     }
                 })
             }
@@ -192,7 +180,7 @@ impl<'a> OperationField<'a> {
 
                 if constraint.is_unit() || constraint.is_optional() {
                     Some(quote! {
-                      let _ = self.operation.remove_attribute(#name);
+                      self.operation.remove_attribute(#name)
                     })
                 } else {
                     None
@@ -239,7 +227,7 @@ impl<'a> OperationField<'a> {
             let ident = sanitize_name_snake(&format!("remove_{}", self.name));
             self.remover_impl().map_or(quote!(), |body| {
                 quote! {
-                    pub fn #ident(&mut self) {
+                    pub fn #ident(&mut self) -> Result<(), ::melior::Error> {
                         #body
                     }
                 }

--- a/macro/tests/operand.rs
+++ b/macro/tests/operand.rs
@@ -24,8 +24,8 @@ fn simple() {
         location,
     );
 
-    assert_eq!(op.lhs(), block.argument(0).unwrap().into());
-    assert_eq!(op.rhs(), block.argument(1).unwrap().into());
+    assert_eq!(op.lhs().unwrap(), block.argument(0).unwrap().into());
+    assert_eq!(op.rhs().unwrap(), block.argument(1).unwrap().into());
     assert_eq!(op.operation().operand_count(), 2);
 }
 
@@ -48,9 +48,15 @@ fn variadic_after_single() {
         location,
     );
 
-    assert_eq!(op.first(), block.argument(0).unwrap().into());
-    assert_eq!(op.others().next(), Some(block.argument(2).unwrap().into()));
-    assert_eq!(op.others().nth(1), Some(block.argument(1).unwrap().into()));
+    assert_eq!(op.first().unwrap(), block.argument(0).unwrap().into());
+    assert_eq!(
+        op.others().unwrap().next(),
+        Some(block.argument(2).unwrap().into())
+    );
+    assert_eq!(
+        op.others().unwrap().nth(1),
+        Some(block.argument(1).unwrap().into())
+    );
     assert_eq!(op.operation().operand_count(), 3);
-    assert_eq!(op.others().count(), 2);
+    assert_eq!(op.others().unwrap().count(), 2);
 }

--- a/macro/tests/operand.rs
+++ b/macro/tests/operand.rs
@@ -49,14 +49,8 @@ fn variadic_after_single() {
     );
 
     assert_eq!(op.first().unwrap(), block.argument(0).unwrap().into());
-    assert_eq!(
-        op.others().unwrap().next(),
-        Some(block.argument(2).unwrap().into())
-    );
-    assert_eq!(
-        op.others().unwrap().nth(1),
-        Some(block.argument(1).unwrap().into())
-    );
+    assert_eq!(op.others().next(), Some(block.argument(2).unwrap().into()));
+    assert_eq!(op.others().nth(1), Some(block.argument(1).unwrap().into()));
     assert_eq!(op.operation().operand_count(), 3);
-    assert_eq!(op.others().unwrap().count(), 2);
+    assert_eq!(op.others().count(), 2);
 }

--- a/macro/tests/region.rs
+++ b/macro/tests/region.rs
@@ -22,7 +22,7 @@ fn single() {
         region_test::single(r1, location)
     };
 
-    assert!(op.default_region().first_block().is_some());
+    assert!(op.default_region().unwrap().first_block().is_some());
 }
 
 #[test]
@@ -51,7 +51,7 @@ fn variadic_after_single() {
 
     assert_eq!(op.operation().to_string(), op2.operation().to_string());
 
-    assert!(op.default_region().first_block().is_none());
+    assert!(op.default_region().unwrap().first_block().is_none());
     assert_eq!(op.other_regions().count(), 2);
     assert!(op.other_regions().next().unwrap().first_block().is_some());
     assert!(op.other_regions().nth(1).unwrap().first_block().is_none());

--- a/melior/src/error.rs
+++ b/melior/src/error.rs
@@ -1,4 +1,5 @@
 use std::{
+    convert::Infallible,
     error,
     fmt::{self, Display, Formatter},
     str::Utf8Error,
@@ -15,6 +16,7 @@ pub enum Error {
         value: String,
     },
     InvokeFunction,
+    OperandNotFound(&'static str),
     OperationResultExpected(String),
     PositionOutOfBounds {
         name: &'static str,
@@ -22,10 +24,12 @@ pub enum Error {
         index: usize,
     },
     ParsePassPipeline(String),
+    ResultNotFound(&'static str),
     RunPass,
     TypeExpected(&'static str, String),
     UnknownDiagnosticSeverity(u32),
     Utf8(Utf8Error),
+    Infallible,
 }
 
 impl Display for Error {
@@ -44,6 +48,9 @@ impl Display for Error {
                 write!(formatter, "element of {type} type expected: {value}")
             }
             Self::InvokeFunction => write!(formatter, "failed to invoke JIT-compiled function"),
+            Self::OperandNotFound(name) => {
+                write!(formatter, "operand {name} not found")
+            }
             Self::OperationResultExpected(value) => {
                 write!(formatter, "operation result expected: {value}")
             }
@@ -52,6 +59,9 @@ impl Display for Error {
             }
             Self::PositionOutOfBounds { name, value, index } => {
                 write!(formatter, "{name} position {index} out of bounds: {value}")
+            }
+            Self::ResultNotFound(name) => {
+                write!(formatter, "result {name} not found")
             }
             Self::RunPass => write!(formatter, "failed to run pass"),
             Self::TypeExpected(r#type, actual) => {
@@ -63,6 +73,9 @@ impl Display for Error {
             Self::Utf8(error) => {
                 write!(formatter, "{}", error)
             }
+            Self::Infallible => {
+                write!(formatter, "infallible")
+            }
         }
     }
 }
@@ -72,5 +85,11 @@ impl error::Error for Error {}
 impl From<Utf8Error> for Error {
     fn from(error: Utf8Error) -> Self {
         Self::Utf8(error)
+    }
+}
+
+impl From<Infallible> for Error {
+    fn from(_: Infallible) -> Self {
+        Self::Infallible
     }
 }

--- a/melior/src/error.rs
+++ b/melior/src/error.rs
@@ -29,7 +29,6 @@ pub enum Error {
     TypeExpected(&'static str, String),
     UnknownDiagnosticSeverity(u32),
     Utf8(Utf8Error),
-    Infallible,
 }
 
 impl Display for Error {
@@ -73,9 +72,6 @@ impl Display for Error {
             Self::Utf8(error) => {
                 write!(formatter, "{}", error)
             }
-            Self::Infallible => {
-                write!(formatter, "infallible")
-            }
         }
     }
 }
@@ -90,6 +86,6 @@ impl From<Utf8Error> for Error {
 
 impl From<Infallible> for Error {
     fn from(_: Infallible) -> Self {
-        Self::Infallible
+        unreachable!()
     }
 }


### PR DESCRIPTION
As previously suggested in #274, I replaced the `.expect` with returning a `Result` in the operation accessors of ODS generated dialects.

I also added some variants to the `Error` enum to support this. The `Infallible` variant was added to allow using `TryInto` to convert `Attribute` into itself, such that we avoid needing to handle `Attribute` differently from `StringAttribute`, `IntAttribute`, etc. But if you prefer, I can change the macro code to deal with this case instead, I'm honestly not a big fan of my `Infallible` hack either.