### PR TITLE
Refactor OperationField

### DIFF
--- a/macro/src/dialect/operation/accessors.rs
+++ b/macro/src/dialect/operation/accessors.rs
@@ -19,7 +19,6 @@ impl<'a> OperationField<'a> {
                 let error_variant = match kind {
                     ElementKind::Operand => quote!(OperandNotFound),
                     ElementKind::Result => quote!(ResultNotFound),
-                    _ => unreachable!(),
                 };
                 let name = self.name;
 

--- a/macro/src/dialect/operation/accessors.rs
+++ b/macro/src/dialect/operation/accessors.rs
@@ -211,7 +211,7 @@ impl<'a> OperationField<'a> {
         let setter = {
             let ident = sanitize_name_snake(&format!("set_{}", self.name));
             self.setter_impl().map_or(quote!(), |body| {
-                let param_type = &self.param_type;
+                let param_type = &self.kind.param_type();
                 quote! {
                     pub fn #ident(&mut self, value: #param_type) {
                         #body
@@ -231,7 +231,7 @@ impl<'a> OperationField<'a> {
         };
         let getter = {
             let ident = &self.sanitized_name;
-            let return_type = &self.return_type;
+            let return_type = &self.kind.return_type();
             self.getter_impl().map_or(quote!(), |body| {
                 quote! {
                     pub fn #ident(&self) -> #return_type {

--- a/macro/src/dialect/operation/builder.rs
+++ b/macro/src/dialect/operation/builder.rs
@@ -97,7 +97,7 @@ impl<'o, 'c> OperationBuilder<'o, 'c> {
         let builder_ident = format_ident!("{}Builder", self.operation.class_name);
         self.operation.fields.iter().map(move |field| {
             let name = sanitize_name_snake(field.name);
-            let st = &field.param_type;
+            let st = &field.kind.param_type();
             let args = quote! { #name: #st };
             let add = format_ident!("add_{}s", field.kind.as_str());
 
@@ -281,7 +281,7 @@ impl<'o, 'c> OperationBuilder<'o, 'c> {
         let mut args = required_fields
             .clone()
             .map(|field| {
-                let param_type = &field.param_type;
+                let param_type = &field.kind.param_type();
                 let param_name = &field.sanitized_name;
                 quote! { #param_name: #param_type }
             })


### PR DESCRIPTION
Moved most `OperationField` fields to specific variants of the `FieldKind` enum and moved `param_type` and `return_type` to methods instead of determining them when constructing the `OperationField`.

I'm also refactoring the `Operation::from_def` method for a later PR, since it's way to large and hard to read. I'm replacing the `VariadicKind` updating with a more idiomatic `VariadicKindIter` that implements `Iterator`.