### PR TITLE
Refactor `Operation::from_def`

### DIFF
--- a/macro/src/dialect/operation/accessors.rs
+++ b/macro/src/dialect/operation/accessors.rs
@@ -19,7 +19,6 @@ impl<'a> OperationField<'a> {
                 let error_variant = match kind {
                     ElementKind::Operand => quote!(OperandNotFound),
                     ElementKind::Result => quote!(ResultNotFound),
-                    _ => unreachable!(),
                 };
                 let name = self.name;
 

--- a/macro/src/dialect/operation/accessors.rs
+++ b/macro/src/dialect/operation/accessors.rs
@@ -211,7 +211,7 @@ impl<'a> OperationField<'a> {
         let setter = {
             let ident = sanitize_name_snake(&format!("set_{}", self.name));
             self.setter_impl().map_or(quote!(), |body| {
-                let param_type = &self.param_type;
+                let param_type = &self.kind.param_type();
                 quote! {
                     pub fn #ident(&mut self, value: #param_type) {
                         #body
@@ -231,7 +231,7 @@ impl<'a> OperationField<'a> {
         };
         let getter = {
             let ident = &self.sanitized_name;
-            let return_type = &self.return_type;
+            let return_type = &self.kind.return_type();
             self.getter_impl().map_or(quote!(), |body| {
                 quote! {
                     pub fn #ident(&self) -> #return_type {

--- a/macro/src/dialect/operation/builder.rs
+++ b/macro/src/dialect/operation/builder.rs
@@ -97,7 +97,7 @@ impl<'o, 'c> OperationBuilder<'o, 'c> {
         let builder_ident = format_ident!("{}Builder", self.operation.class_name);
         self.operation.fields.iter().map(move |field| {
             let name = sanitize_name_snake(field.name);
-            let st = &field.param_type;
+            let st = &field.kind.param_type();
             let args = quote! { #name: #st };
             let add = format_ident!("add_{}s", field.kind.as_str());
 
@@ -281,7 +281,7 @@ impl<'o, 'c> OperationBuilder<'o, 'c> {
         let mut args = required_fields
             .clone()
             .map(|field| {
-                let param_type = &field.param_type;
+                let param_type = &field.kind.param_type();
                 let param_name = &field.sanitized_name;
                 quote! { #param_name: #param_type }
             })

--- a/macro/src/dialect/operation/builder.rs
+++ b/macro/src/dialect/operation/builder.rs
@@ -95,7 +95,7 @@ impl<'o, 'c> OperationBuilder<'o, 'c> {
         phantoms: &'a [TokenStream],
     ) -> impl Iterator<Item = TokenStream> + 'a {
         let builder_ident = format_ident!("{}Builder", self.operation.class_name);
-        self.operation.fields.iter().map(move |field| {
+        self.operation.fields().map(move |field| {
             let name = sanitize_name_snake(field.name);
             let st = &field.kind.param_type();
             let args = quote! { #name: #st };
@@ -297,7 +297,7 @@ impl<'o, 'c> OperationBuilder<'o, 'c> {
     fn required_fields<'a, 'b>(
         operation: &'a Operation<'b>,
     ) -> impl Iterator<Item = &'a OperationField<'b>> {
-        operation.fields.iter().filter(|field| {
+        operation.fields().filter(|field| {
             !field.kind.is_optional() && (!field.kind.is_result() || !operation.can_infer_type)
         })
     }


### PR DESCRIPTION
I've made the following changes in this PR:

- Split `Operation::from_def` in several `collect_` methods
- Instead of collecting all operation fields into a single `Vec`, collect them into several smaller `Vec`s and chain the iterators on-demand in the `fields` function. This makes it a bit easier to handle errors.
- Replaced `initial_variadic_kind` and `update_variadic_kind` closures with a `VariadicKindIter` such that we can `zip` this iterator with the iterators for operands and results. I'm not sure if this is the best solution, but I do personally prefer it over my previous solution.

There are still some things I'm unsure about, and would like to hear your thoughts. I will add some comments to the code diff.