### PR TITLE
Add support for `mlirExternalPassSignalFailure`

### DIFF
--- a/melior/src/pass.rs
+++ b/melior/src/pass.rs
@@ -11,7 +11,7 @@ pub mod sparse_tensor;
 pub mod transform;
 
 pub use self::{
-    external::{create_external, ExternalPass},
+    external::{create_external, ExternalPass, ExternalPassHandle},
     manager::PassManager,
     operation_manager::OperationPassManager,
 };

--- a/melior/src/pass.rs
+++ b/melior/src/pass.rs
@@ -11,7 +11,7 @@ pub mod sparse_tensor;
 pub mod transform;
 
 pub use self::{
-    external::{create_external, ExternalPass, ExternalPassHandle},
+    external::{create_external, ExternalPass, RunExternalPass},
     manager::PassManager,
     operation_manager::OperationPassManager,
 };

--- a/melior/src/pass/external.rs
+++ b/melior/src/pass/external.rs
@@ -14,7 +14,7 @@ use std::{marker::PhantomData, mem::transmute, ptr::drop_in_place};
 
 #[derive(Clone, Copy, Debug)]
 pub struct ExternalPass<'a> {
-    pub raw: MlirExternalPass,
+    raw: MlirExternalPass,
     _reference: PhantomData<&'a MlirExternalPass>,
 }
 

--- a/melior/src/pass/external.rs
+++ b/melior/src/pass/external.rs
@@ -13,12 +13,12 @@ use mlir_sys::{
 use std::{marker::PhantomData, mem::transmute, ptr::drop_in_place};
 
 #[derive(Clone, Copy, Debug)]
-pub struct ExternalPassHandle<'a> {
+pub struct ExternalPass<'a> {
     pub raw: MlirExternalPass,
     _reference: PhantomData<&'a MlirExternalPass>,
 }
 
-impl<'a> ExternalPassHandle<'a> {
+impl<'a> ExternalPass<'a> {
     /// Signals that the pass has failed.
     pub fn signal_failure(self) {
         unsafe { mlirExternalPassSignalFailure(self.raw) }
@@ -42,20 +42,20 @@ impl<'a> ExternalPassHandle<'a> {
     }
 }
 
-unsafe extern "C" fn callback_construct<'a, T: ExternalPass<'a>>(pass: *mut T) {
+unsafe extern "C" fn callback_construct<'a, T: RunExternalPass<'a>>(pass: *mut T) {
     pass.as_mut()
         .expect("pass should be valid when called")
         .construct();
 }
 
-unsafe extern "C" fn callback_destruct<'a, T: ExternalPass<'a>>(pass: *mut T) {
+unsafe extern "C" fn callback_destruct<'a, T: RunExternalPass<'a>>(pass: *mut T) {
     pass.as_mut()
         .expect("pass should be valid when called")
         .destruct();
     drop_in_place(pass);
 }
 
-unsafe extern "C" fn callback_initialize<'a, T: ExternalPass<'a>>(
+unsafe extern "C" fn callback_initialize<'a, T: RunExternalPass<'a>>(
     ctx: MlirContext,
     pass: *mut T,
 ) -> MlirLogicalResult {
@@ -65,7 +65,7 @@ unsafe extern "C" fn callback_initialize<'a, T: ExternalPass<'a>>(
     MlirLogicalResult { value: 1 }
 }
 
-unsafe extern "C" fn callback_run<'a, T: ExternalPass<'a>>(
+unsafe extern "C" fn callback_run<'a, T: RunExternalPass<'a>>(
     op: MlirOperation,
     mlir_pass: MlirExternalPass,
     pass: *mut T,
@@ -74,11 +74,11 @@ unsafe extern "C" fn callback_run<'a, T: ExternalPass<'a>>(
         .expect("pass should be valid when called")
         .run(
             OperationRef::from_raw(op),
-            ExternalPassHandle::from_raw(mlir_pass),
+            ExternalPass::from_raw(mlir_pass),
         )
 }
 
-unsafe extern "C" fn callback_clone<'a, T: ExternalPass<'a>>(pass: *mut T) -> *mut T {
+unsafe extern "C" fn callback_clone<'a, T: RunExternalPass<'a>>(pass: *mut T) -> *mut T {
     Box::<T>::into_raw(Box::new(
         pass.as_mut()
             .expect("pass should be valid when called")
@@ -98,14 +98,14 @@ unsafe extern "C" fn callback_clone<'a, T: ExternalPass<'a>>(pass: *mut T) -> *m
 /// ```
 /// use melior::{
 ///     ir::OperationRef,
-///     pass::{ExternalPass, ExternalPassHandle},
+///     pass::{ExternalPass, RunExternalPass},
 ///     ContextRef,
 /// };
 ///
 /// #[derive(Clone, Debug)]
 /// struct ExamplePass;
 ///
-/// impl<'c> ExternalPass<'c> for ExamplePass {
+/// impl<'c> RunExternalPass<'c> for ExamplePass {
 ///     fn construct(&mut self) {
 ///         println!("Constructed pass!");
 ///     }
@@ -114,22 +114,22 @@ unsafe extern "C" fn callback_clone<'a, T: ExternalPass<'a>>(pass: *mut T) -> *m
 ///         println!("Initialize called!");
 ///     }
 ///
-///     fn run(&mut self, operation: OperationRef<'c, '_>, _pass: ExternalPassHandle<'_>) {
+///     fn run(&mut self, operation: OperationRef<'c, '_>, _pass: ExternalPass<'_>) {
 ///         operation.dump();
 ///     }
 /// }
 /// ```
-pub trait ExternalPass<'c>: Sized + Clone {
+pub trait RunExternalPass<'c>: Sized + Clone {
     fn construct(&mut self) {}
     fn destruct(&mut self) {}
     fn initialize(&mut self, context: ContextRef<'c>);
-    fn run(&mut self, operation: OperationRef<'c, '_>, pass: ExternalPassHandle<'_>);
+    fn run(&mut self, operation: OperationRef<'c, '_>, pass: ExternalPass<'_>);
 }
 
-impl<'c, F: FnMut(OperationRef<'c, '_>, ExternalPassHandle<'_>) + Clone> ExternalPass<'c> for F {
+impl<'c, F: FnMut(OperationRef<'c, '_>, ExternalPass<'_>) + Clone> RunExternalPass<'c> for F {
     fn initialize(&mut self, _context: ContextRef<'c>) {}
 
-    fn run(&mut self, operation: OperationRef<'c, '_>, pass: ExternalPassHandle<'_>) {
+    fn run(&mut self, operation: OperationRef<'c, '_>, pass: ExternalPass<'_>) {
         self(operation, pass)
     }
 }
@@ -141,7 +141,7 @@ impl<'c, F: FnMut(OperationRef<'c, '_>, ExternalPassHandle<'_>) + Clone> Externa
 /// ```
 /// use melior::{
 ///     ir::{r#type::TypeId, OperationRef},
-///     pass::{create_external, ExternalPassHandle},
+///     pass::{create_external, ExternalPass},
 /// };
 ///
 /// #[repr(align(8))]
@@ -150,7 +150,7 @@ impl<'c, F: FnMut(OperationRef<'c, '_>, ExternalPassHandle<'_>) + Clone> Externa
 /// static EXAMPLE_PASS: PassId = PassId;
 ///
 /// create_external(
-///     |operation: OperationRef, _pass: ExternalPassHandle| {
+///     |operation: OperationRef, _pass: ExternalPass| {
 ///         operation.dump();
 ///     },
 ///     TypeId::create(&EXAMPLE_PASS),
@@ -161,7 +161,7 @@ impl<'c, F: FnMut(OperationRef<'c, '_>, ExternalPassHandle<'_>) + Clone> Externa
 ///     &[],
 /// );
 /// ```
-pub fn create_external<'c, T: ExternalPass<'c>>(
+pub fn create_external<'c, T: RunExternalPass<'c>>(
     pass: T,
     pass_id: TypeId,
     name: &str,
@@ -240,7 +240,7 @@ mod tests {
             value: i32,
         }
 
-        impl<'c> ExternalPass<'c> for TestPass {
+        impl<'c> RunExternalPass<'c> for TestPass {
             fn construct(&mut self) {
                 assert_eq!(self.value, 10);
             }
@@ -254,7 +254,7 @@ mod tests {
                 self.value = 20;
             }
 
-            fn run(&mut self, operation: OperationRef<'c, '_>, _pass: ExternalPassHandle<'_>) {
+            fn run(&mut self, operation: OperationRef<'c, '_>, _pass: ExternalPass<'_>) {
                 assert_eq!(self.value, 20);
                 self.value = 30;
                 assert!(operation.verify());
@@ -306,7 +306,7 @@ mod tests {
         let pass_manager = PassManager::new(&context);
 
         pass_manager.add_pass(create_external(
-            |operation: OperationRef, pass: ExternalPassHandle<'_>| {
+            |operation: OperationRef, pass: ExternalPass<'_>| {
                 assert!(operation.verify());
                 assert!(
                     operation

--- a/melior/src/pass/external.rs
+++ b/melior/src/pass/external.rs
@@ -7,10 +7,40 @@ use crate::{
     ContextRef, StringRef,
 };
 use mlir_sys::{
-    mlirCreateExternalPass, MlirContext, MlirExternalPass, MlirExternalPassCallbacks,
-    MlirLogicalResult, MlirOperation,
+    mlirCreateExternalPass, mlirExternalPassSignalFailure, MlirContext, MlirExternalPass,
+    MlirExternalPassCallbacks, MlirLogicalResult, MlirOperation,
 };
-use std::{mem::transmute, ptr::drop_in_place};
+use std::{marker::PhantomData, mem::transmute, ptr::drop_in_place};
+
+#[derive(Clone, Copy, Debug)]
+pub struct ExternalPassHandle<'a> {
+    pub raw: MlirExternalPass,
+    _reference: PhantomData<&'a MlirExternalPass>,
+}
+
+impl<'a> ExternalPassHandle<'a> {
+    /// Signals that the pass has failed.
+    pub fn signal_failure(self) {
+        unsafe { mlirExternalPassSignalFailure(self.raw) }
+    }
+
+    /// Converts an external pass to a raw object.
+    pub fn to_raw(self) -> MlirExternalPass {
+        self.raw
+    }
+
+    /// Creates an external pass handle from a raw object.
+    ///
+    /// # Safety
+    ///
+    /// A raw object must be valid.
+    pub const unsafe fn from_raw(raw: MlirExternalPass) -> Self {
+        Self {
+            raw,
+            _reference: PhantomData,
+        }
+    }
+}
 
 unsafe extern "C" fn callback_construct<'a, T: ExternalPass<'a>>(pass: *mut T) {
     pass.as_mut()
@@ -37,12 +67,15 @@ unsafe extern "C" fn callback_initialize<'a, T: ExternalPass<'a>>(
 
 unsafe extern "C" fn callback_run<'a, T: ExternalPass<'a>>(
     op: MlirOperation,
-    _mlir_pass: MlirExternalPass,
+    mlir_pass: MlirExternalPass,
     pass: *mut T,
 ) {
     pass.as_mut()
         .expect("pass should be valid when called")
-        .run(OperationRef::from_raw(op))
+        .run(
+            OperationRef::from_raw(op),
+            ExternalPassHandle::from_raw(mlir_pass),
+        )
 }
 
 unsafe extern "C" fn callback_clone<'a, T: ExternalPass<'a>>(pass: *mut T) -> *mut T {
@@ -65,7 +98,7 @@ unsafe extern "C" fn callback_clone<'a, T: ExternalPass<'a>>(pass: *mut T) -> *m
 /// ```
 /// use melior::{
 ///     ir::OperationRef,
-///     pass::ExternalPass,
+///     pass::{ExternalPass, ExternalPassHandle},
 ///     ContextRef,
 /// };
 ///
@@ -81,7 +114,7 @@ unsafe extern "C" fn callback_clone<'a, T: ExternalPass<'a>>(pass: *mut T) -> *m
 ///         println!("Initialize called!");
 ///     }
 ///
-///     fn run(&mut self, operation: OperationRef<'c, '_>) {
+///     fn run(&mut self, operation: OperationRef<'c, '_>, _pass: ExternalPassHandle<'_>) {
 ///         operation.dump();
 ///     }
 /// }
@@ -90,14 +123,14 @@ pub trait ExternalPass<'c>: Sized + Clone {
     fn construct(&mut self) {}
     fn destruct(&mut self) {}
     fn initialize(&mut self, context: ContextRef<'c>);
-    fn run(&mut self, operation: OperationRef<'c, '_>);
+    fn run(&mut self, operation: OperationRef<'c, '_>, pass: ExternalPassHandle<'_>);
 }
 
-impl<'c, F: FnMut(OperationRef<'c, '_>) + Clone> ExternalPass<'c> for F {
+impl<'c, F: FnMut(OperationRef<'c, '_>, ExternalPassHandle<'_>) + Clone> ExternalPass<'c> for F {
     fn initialize(&mut self, _context: ContextRef<'c>) {}
 
-    fn run(&mut self, operation: OperationRef<'c, '_>) {
-        self(operation)
+    fn run(&mut self, operation: OperationRef<'c, '_>, pass: ExternalPassHandle<'_>) {
+        self(operation, pass)
     }
 }
 
@@ -108,7 +141,7 @@ impl<'c, F: FnMut(OperationRef<'c, '_>) + Clone> ExternalPass<'c> for F {
 /// ```
 /// use melior::{
 ///     ir::{r#type::TypeId, OperationRef},
-///     pass::create_external,
+///     pass::{create_external, ExternalPassHandle},
 /// };
 ///
 /// #[repr(align(8))]
@@ -117,7 +150,7 @@ impl<'c, F: FnMut(OperationRef<'c, '_>) + Clone> ExternalPass<'c> for F {
 /// static EXAMPLE_PASS: PassId = PassId;
 ///
 /// create_external(
-///     |operation: OperationRef| {
+///     |operation: OperationRef, _pass: ExternalPassHandle| {
 ///         operation.dump();
 ///     },
 ///     TypeId::create(&EXAMPLE_PASS),
@@ -221,7 +254,7 @@ mod tests {
                 self.value = 20;
             }
 
-            fn run(&mut self, operation: OperationRef<'c, '_>) {
+            fn run(&mut self, operation: OperationRef<'c, '_>, _pass: ExternalPassHandle<'_>) {
                 assert_eq!(self.value, 20);
                 self.value = 30;
                 assert!(operation.verify());
@@ -264,7 +297,7 @@ mod tests {
     }
 
     #[test]
-    fn external_fn_pass() {
+    fn external_fn_pass_failure() {
         static TEST_FN_PASS: PassId = PassId;
 
         let context = create_test_context();
@@ -273,7 +306,7 @@ mod tests {
         let pass_manager = PassManager::new(&context);
 
         pass_manager.add_pass(create_external(
-            |operation: OperationRef| {
+            |operation: OperationRef, pass: ExternalPassHandle<'_>| {
                 assert!(operation.verify());
                 assert!(
                     operation
@@ -286,6 +319,7 @@ mod tests {
                         .name()
                         == Identifier::new(&operation.context(), "func.func")
                 );
+                pass.signal_failure();
             },
             TypeId::create(&TEST_FN_PASS),
             "test closure",
@@ -294,6 +328,6 @@ mod tests {
             "",
             &[DialectHandle::func()],
         ));
-        pass_manager.run(&mut module).unwrap();
+        assert!(pass_manager.run(&mut module).is_err());
     }
 }


### PR DESCRIPTION
In #251, I overlooked to `mlirExternalPassSignalFailure` function. This requires a wrapper around `MlirExternalPass`, which is a CAPI pointer for the `ExternalPass` subclass of `::mlir::Pass` that represents any external pass and can expose some private methods from `Pass`.

I decided to call this wrapper `ExternalPassHandle`, since we are already using `ExternalPass` for the trait.

I originally made these changes a while ago when experimenting with extending the CAPI for analyses, but decided to make this PR, since `mlirExternalPassSignalFailure` is part of the MLIR CAPI already.