### PR TITLE
memref dimensions should be i64

### DIFF
--- a/melior/src/ir/type/mem_ref.rs
+++ b/melior/src/ir/type/mem_ref.rs
@@ -18,7 +18,7 @@ impl<'c> MemRefType<'c> {
     /// Creates a mem-ref type.
     pub fn new(
         r#type: Type<'c>,
-        dimensions: &[u64],
+        dimensions: &[i64],
         layout: Option<Attribute<'c>>,
         memory_space: Option<Attribute<'c>>,
     ) -> Self {


### PR DESCRIPTION
If you make a memref type with i64::MAX - 1 you will see the output shows memref<-1xTYPE>

also the pointer in mlir-sys is a *i64

By the way, do you know how to make a memref like memref<?xTYPE> ?