### PR TITLE
add derefmut for operationref

### DIFF
--- a/melior/src/ir/operation.rs
+++ b/melior/src/ir/operation.rs
@@ -31,7 +31,7 @@ use std::{
     ffi::c_void,
     fmt::{Debug, Display, Formatter},
     marker::PhantomData,
-    ops::Deref,
+    ops::{Deref, DerefMut},
 };
 
 /// An operation.
@@ -393,6 +393,12 @@ impl<'c, 'a> Deref for OperationRef<'c, 'a> {
     type Target = Operation<'a>;
 
     fn deref(&self) -> &Self::Target {
+        unsafe { transmute(self) }
+    }
+}
+
+impl<'c, 'a> DerefMut for OperationRef<'c, 'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { transmute(self) }
     }
 }

--- a/melior/src/ir/operation.rs
+++ b/melior/src/ir/operation.rs
@@ -358,6 +358,22 @@ impl<'c, 'a> OperationRef<'c, 'a> {
         transmute(self)
     }
 
+    /// Gets an mutable operation.
+    ///
+    /// This function is different from `deref` because the correct lifetime is
+    /// kept for the return type.
+    ///
+    /// # Safety
+    ///
+    /// The returned reference is safe to use only in the lifetime scope of the
+    /// operation reference.
+    pub unsafe fn to_ref_mut(&mut self) -> &'a mut Operation<'c> {
+        // As we can't deref OperationRef<'a> into `&'a Operation`, we forcibly cast its
+        // lifetime here to extend it from the lifetime of `ObjectRef<'a>` itself into
+        // `'a`.
+        transmute(self)
+    }
+
     /// Converts an operation reference into a raw object.
     pub const fn to_raw(self) -> MlirOperation {
         self.raw
@@ -393,12 +409,6 @@ impl<'c, 'a> Deref for OperationRef<'c, 'a> {
     type Target = Operation<'a>;
 
     fn deref(&self) -> &Self::Target {
-        unsafe { transmute(self) }
-    }
-}
-
-impl<'c, 'a> DerefMut for OperationRef<'c, 'a> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { transmute(self) }
     }
 }

--- a/melior/src/ir/operation.rs
+++ b/melior/src/ir/operation.rs
@@ -31,7 +31,7 @@ use std::{
     ffi::c_void,
     fmt::{Debug, Display, Formatter},
     marker::PhantomData,
-    ops::{Deref, DerefMut},
+    ops::Deref,
 };
 
 /// An operation.

--- a/melior/src/ir/operation.rs
+++ b/melior/src/ir/operation.rs
@@ -342,7 +342,7 @@ impl<'c, 'a> OperationRef<'c, 'a> {
         unsafe { self.to_ref() }.result(index)
     }
 
-    /// Gets an operation.
+    /// Gets a operation.
     ///
     /// This function is different from `deref` because the correct lifetime is
     /// kept for the return type.


### PR DESCRIPTION
I wanted to modify the module operation by adding a attribute, but apparently operationref doesnt implement derefmut and set_attribute takes a mutable  self.

Was there a reason this was not there before?