### PR TITLE
Add Bool Attribute

### DIFF
--- a/melior/src/ir/attribute.rs
+++ b/melior/src/ir/attribute.rs
@@ -4,6 +4,7 @@
 mod r#macro;
 mod array;
 mod attribute_like;
+mod bool;
 mod dense_elements;
 mod dense_i32_array;
 mod dense_i64_array;
@@ -14,10 +15,11 @@ mod string;
 mod r#type;
 
 pub use self::{
-    array::ArrayAttribute, attribute_like::AttributeLike, dense_elements::DenseElementsAttribute,
-    dense_i32_array::DenseI32ArrayAttribute, dense_i64_array::DenseI64ArrayAttribute,
-    flat_symbol_ref::FlatSymbolRefAttribute, float::FloatAttribute, integer::IntegerAttribute,
-    r#type::TypeAttribute, string::StringAttribute,
+    array::ArrayAttribute, attribute_like::AttributeLike, bool::BoolAttribute,
+    dense_elements::DenseElementsAttribute, dense_i32_array::DenseI32ArrayAttribute,
+    dense_i64_array::DenseI64ArrayAttribute, flat_symbol_ref::FlatSymbolRefAttribute,
+    float::FloatAttribute, integer::IntegerAttribute, r#type::TypeAttribute,
+    string::StringAttribute,
 };
 use crate::{context::Context, string_ref::StringRef, utility::print_callback};
 use mlir_sys::{
@@ -123,6 +125,7 @@ impl<'c> Debug for Attribute<'c> {
 from_subtypes!(
     Attribute,
     ArrayAttribute,
+    BoolAttribute,
     DenseElementsAttribute,
     DenseI32ArrayAttribute,
     DenseI64ArrayAttribute,

--- a/melior/src/ir/attribute/bool.rs
+++ b/melior/src/ir/attribute/bool.rs
@@ -1,0 +1,42 @@
+use super::{Attribute, AttributeLike};
+use crate::{Context, Error};
+use mlir_sys::{mlirBoolAttrGet, mlirBoolAttrGetValue, MlirAttribute};
+
+/// A bool attribute.
+#[derive(Clone, Copy)]
+pub struct BoolAttribute<'c> {
+    attribute: Attribute<'c>,
+}
+
+impl<'c> BoolAttribute<'c> {
+    /// Creates a bool attribute.
+    pub fn new(context: &'c Context, boolean: bool) -> Self {
+        unsafe {
+            Self::from_raw(mlirBoolAttrGet(
+                context.to_raw(),
+                if boolean { 1 } else { 0 },
+            ))
+        }
+    }
+
+    /// Returns a value.
+    pub fn value(&self) -> bool {
+        unsafe { mlirBoolAttrGetValue(self.to_raw()) }
+    }
+}
+
+attribute_traits!(BoolAttribute, is_string, "string");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::create_test_context;
+
+    #[test]
+    fn value() {
+        let context = create_test_context();
+        let value = BoolAttribute::new(&context, true).value();
+
+        assert_eq!(value, true);
+    }
+}


### PR DESCRIPTION
This was motivated by my attempt to build a JIT compiler that links with existing rust code. This requires 
`attributes { llvm.emit_c_interface }` to invoke the MLIR compiled function.

I am very new to MLIR, so please double check this PR. 

-----

**Edit:** Looks like I did made a mistake for my usecase. I should have been using the `UnitAttr`. 

Regardless, hopefully this PR is still useful. 