### PR TITLE
Moses/fix bool attribute macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,7 @@ dependencies = [
  "dashmap",
  "indoc",
  "insta",
+ "libc",
  "melior-macro",
  "mlir-sys",
  "once_cell",

--- a/melior/Cargo.toml
+++ b/melior/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["mlir", "llvm"]
 ods-dialects = []
 
 [dependencies]
+libc = "0.2"
 dashmap = "5.5.3"
 melior-macro = { version = "0.10", path = "../macro" }
 mlir-sys = "0.2"
@@ -21,3 +22,6 @@ once_cell = "1"
 indoc = "2.0.5"
 insta = "1.38.0"
 pretty_assertions = "1.4.0"
+
+[patch.crates-io]
+tblgen = { git = "https://gitlab.com/Doout/tblgen-rs.git", branch = "master" }

--- a/melior/src/ir/attribute/bool.rs
+++ b/melior/src/ir/attribute/bool.rs
@@ -25,7 +25,7 @@ impl<'c> BoolAttribute<'c> {
     }
 }
 
-attribute_traits!(BoolAttribute, is_string, "string");
+attribute_traits!(BoolAttribute, bool, "bool");
 
 #[cfg(test)]
 mod tests {

--- a/melior/src/string_ref.rs
+++ b/melior/src/string_ref.rs
@@ -17,7 +17,7 @@ impl<'a> StringRef<'a> {
     /// Creates a string reference.
     pub fn new(string: &'a str) -> Self {
         let string = MlirStringRef {
-            data: string.as_bytes().as_ptr() as *const i8,
+            data: string.as_bytes().as_ptr() as *const libc::c_char,
             length: string.len(),
         };
 


### PR DESCRIPTION
Fixes issue where bools were being checked if they were strings, but they should be checked if they're bools.

anyways it's fixed.