### PR TITLE
Update `tblgen-alt` dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "tblgen-alt"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8128e684b18b518f32cd15779659c4a8dbb54ef6a36b532f7e3520f27dd01c95"
+checksum = "7ae726d43658a13a9cd479de814be1311fea69236cd821e931a4fb9ca4d70e50"
 dependencies = [
  "bindgen",
  "cc",

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -20,7 +20,7 @@ proc-macro2 = "1"
 quote = "1"
 regex = "1.10.4"
 syn = { version = "2", features = ["full"] }
-tblgen = { version = "0.3.3", features = ["llvm18-0"], default-features = false, package = "tblgen-alt" }
+tblgen = { version = "0.3.6", features = ["llvm18-0"], default-features = false, package = "tblgen-alt" }
 unindent = "0.2.3"
 
 [dev-dependencies]


### PR DESCRIPTION
This PR updates the `tblgen-alt` dependency.
The new version of `tblgen-alt` fixes compilation errors on arm64 linux systems.