### PR TITLE
Fix aarch64 linux build.

### DIFF
--- a/melior/src/string_ref.rs
+++ b/melior/src/string_ref.rs
@@ -17,7 +17,7 @@ impl<'a> StringRef<'a> {
     /// Creates a string reference.
     pub fn new(string: &'a str) -> Self {
         let string = MlirStringRef {
-            data: string.as_bytes().as_ptr() as *const i8,
+            data: string.as_bytes().as_ptr() as *const _,
             length: string.len(),
         };
 


### PR DESCRIPTION
Building `melior` for Linux ARM doesn't work because of FFI types. This PR fixes this by making the compiler select the target pointer type automatically. It's the same issue we had in `tblgen-rs-alt`.