### PR TITLE
Cleanup aided by clippy

### DIFF
--- a/macro/src/dialect/input.rs
+++ b/macro/src/dialect/input.rs
@@ -48,7 +48,7 @@ impl Parse for DialectInput {
         }
 
         Ok(Self {
-            name: name.ok_or(input.error("dialect name required"))?,
+            name: name.ok_or_else(|| input.error("dialect name required"))?,
             table_gen,
             td_file,
             include_directories: includes,

--- a/macro/src/dialect/operation.rs
+++ b/macro/src/dialect/operation.rs
@@ -108,15 +108,15 @@ impl<'a> Operation<'a> {
         &self.name
     }
 
-    pub fn can_infer_type(&self) -> bool {
+    pub const fn can_infer_type(&self) -> bool {
         self.can_infer_type
     }
 
-    pub fn dialect_name(&self) -> &str {
+    pub const fn dialect_name(&self) -> &str {
         self.dialect_name
     }
 
-    pub fn operation_name(&self) -> &str {
+    pub const fn operation_name(&self) -> &str {
         self.operation_name
     }
 
@@ -153,7 +153,7 @@ impl<'a> Operation<'a> {
         &self.description
     }
 
-    pub fn constructor_identifier(&self) -> &Ident {
+    pub const fn constructor_identifier(&self) -> &Ident {
         &self.constructor_identifier
     }
 

--- a/macro/src/dialect/operation.rs
+++ b/macro/src/dialect/operation.rs
@@ -227,7 +227,7 @@ impl<'a> Operation<'a> {
             .chain(self.required_attributes().map(convert))
     }
 
-    fn collect_successors(definition: Record<'a>) -> Result<Vec<Successor>, Error> {
+    fn collect_successors(definition: Record<'a>) -> Result<Vec<Successor<'a>>, Error> {
         definition
             .dag_value("successors")?
             .args()
@@ -242,7 +242,7 @@ impl<'a> Operation<'a> {
             .collect()
     }
 
-    fn collect_regions(definition: Record<'a>) -> Result<Vec<Region>, Error> {
+    fn collect_regions(definition: Record<'a>) -> Result<Vec<Region<'a>>, Error> {
         definition
             .dag_value("regions")?
             .args()
@@ -307,7 +307,7 @@ impl<'a> Operation<'a> {
         definition: Record<'a>,
         same_size: bool,
         attribute_sized: bool,
-    ) -> Result<(Vec<OperationResult>, usize), Error> {
+    ) -> Result<(Vec<OperationResult<'a>>, usize), Error> {
         Self::collect_elements(
             &Self::dag_constraints(definition, "results")?
                 .into_iter()

--- a/macro/src/dialect/operation/attribute.rs
+++ b/macro/src/dialect/operation/attribute.rs
@@ -100,11 +100,11 @@ impl<'a> Attribute<'a> {
         })
     }
 
-    pub fn set_identifier(&self) -> &Ident {
+    pub const fn set_identifier(&self) -> &Ident {
         &self.set_identifier
     }
 
-    pub fn remove_identifier(&self) -> &Ident {
+    pub const fn remove_identifier(&self) -> &Ident {
         &self.remove_identifier
     }
 

--- a/macro/src/dialect/operation/builder.rs
+++ b/macro/src/dialect/operation/builder.rs
@@ -20,15 +20,15 @@ impl<'a> OperationBuilder<'a> {
         }
     }
 
-    pub fn operation(&self) -> &Operation {
+    pub const fn operation(&self) -> &Operation {
         self.operation
     }
 
-    pub fn identifier(&self) -> &Ident {
+    pub const fn identifier(&self) -> &Ident {
         &self.identifier
     }
 
-    pub fn type_state(&self) -> &TypeState {
+    pub const fn type_state(&self) -> &TypeState {
         &self.type_state
     }
 

--- a/macro/src/dialect/operation/builder/type_state.rs
+++ b/macro/src/dialect/operation/builder/type_state.rs
@@ -18,7 +18,7 @@ pub struct TypeState {
 }
 
 impl TypeState {
-    pub fn new(
+    pub const fn new(
         results: Vec<String>,
         operands: Vec<String>,
         regions: Vec<String>,

--- a/macro/src/dialect/operation/region.rs
+++ b/macro/src/dialect/operation/region.rs
@@ -23,7 +23,7 @@ impl<'a> Region<'a> {
         })
     }
 
-    pub fn is_variadic(&self) -> bool {
+    pub const fn is_variadic(&self) -> bool {
         self.variadic
     }
 }

--- a/macro/src/dialect/operation/successor.rs
+++ b/macro/src/dialect/operation/successor.rs
@@ -23,7 +23,7 @@ impl<'a> Successor<'a> {
         })
     }
 
-    pub fn is_variadic(&self) -> bool {
+    pub const fn is_variadic(&self) -> bool {
         self.variadic
     }
 }

--- a/macro/src/dialect/type.rs
+++ b/macro/src/dialect/type.rs
@@ -16,21 +16,21 @@ impl Type {
         }
     }
 
-    pub fn is_optional(&self) -> bool {
+    pub const fn is_optional(&self) -> bool {
         self.optional
     }
 
-    pub fn is_variadic(&self) -> bool {
+    pub const fn is_variadic(&self) -> bool {
         self.variadic
     }
 
     // TODO Support variadic-of-variadic.
     #[allow(unused)]
-    pub fn is_variadic_of_variadic(&self) -> bool {
+    pub const fn is_variadic_of_variadic(&self) -> bool {
         self.variadic_of_variadic
     }
 
-    pub fn is_unfixed(&self) -> bool {
+    pub const fn is_unfixed(&self) -> bool {
         self.is_variadic() || self.is_optional()
     }
 }

--- a/macro/src/dialect/utility.rs
+++ b/macro/src/dialect/utility.rs
@@ -36,7 +36,7 @@ fn sanitize_name(name: &str) -> Result<Ident, Error> {
 
     // Try to parse the string as an ident, and prefix the identifier
     // with "r#" if it is not a valid identifier.
-    Ok(syn::parse_str::<Ident>(&name).unwrap_or(format_ident!("r#{}", name)))
+    Ok(syn::parse_str::<Ident>(&name).unwrap_or_else(|_| format_ident!("r#{}", name)))
 }
 
 pub fn sanitize_documentation(string: &str) -> Result<String, Error> {

--- a/melior/src/context.rs
+++ b/melior/src/context.rs
@@ -184,19 +184,19 @@ impl<'c> ContextRef<'c> {
     }
 }
 
-impl<'c> PartialEq for ContextRef<'c> {
+impl PartialEq for ContextRef<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { mlirContextEqual(self.raw, other.raw) }
     }
 }
 
-impl<'c> PartialEq<Context> for ContextRef<'c> {
+impl PartialEq<Context> for ContextRef<'_> {
     fn eq(&self, other: &Context) -> bool {
         self == &other.to_ref()
     }
 }
 
-impl<'c> Eq for ContextRef<'c> {}
+impl Eq for ContextRef<'_> {}
 
 #[cfg(test)]
 mod tests {
@@ -320,7 +320,7 @@ mod tests {
     fn context_to_ref() {
         let ctx = Context::new();
         let ctx_ref = ctx.to_ref();
-        let ctx_ref_to_ref: &Context = unsafe { &ctx_ref.to_ref() };
+        let ctx_ref_to_ref: &Context = unsafe { ctx_ref.to_ref() };
 
         assert_eq!(&ctx_ref, ctx_ref_to_ref);
     }

--- a/melior/src/diagnostic.rs
+++ b/melior/src/diagnostic.rs
@@ -21,7 +21,7 @@ pub struct Diagnostic<'c> {
     phantom: PhantomData<&'c ()>,
 }
 
-impl<'c> Diagnostic<'c> {
+impl Diagnostic<'_> {
     pub fn location(&self) -> Location {
         unsafe { Location::from_raw(mlirDiagnosticGetLocation(self.raw)) }
     }
@@ -60,7 +60,7 @@ impl<'c> Diagnostic<'c> {
     }
 }
 
-impl<'a> Display for Diagnostic<'a> {
+impl Display for Diagnostic<'_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         let mut data = (formatter, Ok(()));
 

--- a/melior/src/dialect.rs
+++ b/melior/src/dialect.rs
@@ -52,13 +52,13 @@ impl<'c> Dialect<'c> {
     }
 }
 
-impl<'c> PartialEq for Dialect<'c> {
+impl PartialEq for Dialect<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { mlirDialectEqual(self.raw, other.raw) }
     }
 }
 
-impl<'c> Eq for Dialect<'c> {}
+impl Eq for Dialect<'_> {}
 
 #[cfg(test)]
 mod tests {

--- a/melior/src/dialect/llvm/load_store_options.rs
+++ b/melior/src/dialect/llvm/load_store_options.rs
@@ -65,7 +65,7 @@ impl<'c> LoadStoreOptions<'c> {
     }
 
     /// Sets TBAA metadata.
-    pub fn tbaa(mut self, tbaa: ArrayAttribute<'c>) -> Self {
+    pub const fn tbaa(mut self, tbaa: ArrayAttribute<'c>) -> Self {
         self.tbaa = Some(tbaa);
         self
     }

--- a/melior/src/ir/affine_map.rs
+++ b/melior/src/ir/affine_map.rs
@@ -43,15 +43,15 @@ impl<'c> AffineMap<'c> {
     }
 }
 
-impl<'c> PartialEq for AffineMap<'c> {
+impl PartialEq for AffineMap<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { mlirAffineMapEqual(self.raw, other.raw) }
     }
 }
 
-impl<'c> Eq for AffineMap<'c> {}
+impl Eq for AffineMap<'_> {}
 
-impl<'c> Display for AffineMap<'c> {
+impl Display for AffineMap<'_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         let mut data = (formatter, Ok(()));
 
@@ -67,7 +67,7 @@ impl<'c> Display for AffineMap<'c> {
     }
 }
 
-impl<'c> Debug for AffineMap<'c> {
+impl Debug for AffineMap<'_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         Display::fmt(self, formatter)
     }

--- a/melior/src/ir/attribute.rs
+++ b/melior/src/ir/attribute.rs
@@ -92,15 +92,15 @@ impl<'c> AttributeLike<'c> for Attribute<'c> {
     }
 }
 
-impl<'c> PartialEq for Attribute<'c> {
+impl PartialEq for Attribute<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { mlirAttributeEqual(self.raw, other.raw) }
     }
 }
 
-impl<'c> Eq for Attribute<'c> {}
+impl Eq for Attribute<'_> {}
 
-impl<'c> Display for Attribute<'c> {
+impl Display for Attribute<'_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         let mut data = (formatter, Ok(()));
 
@@ -116,7 +116,7 @@ impl<'c> Display for Attribute<'c> {
     }
 }
 
-impl<'c> Debug for Attribute<'c> {
+impl Debug for Attribute<'_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         Display::fmt(self, formatter)
     }

--- a/melior/src/ir/block.rs
+++ b/melior/src/ir/block.rs
@@ -209,7 +209,7 @@ impl<'c> Block<'c> {
     }
 
     /// Converts a block into a raw object.
-    pub fn into_raw(self) -> MlirBlock {
+    pub const fn into_raw(self) -> MlirBlock {
         let block = self.raw;
 
         forget(self);

--- a/melior/src/ir/block.rs
+++ b/melior/src/ir/block.rs
@@ -223,21 +223,21 @@ impl<'c> Block<'c> {
     }
 }
 
-impl<'c> Drop for Block<'c> {
+impl Drop for Block<'_> {
     fn drop(&mut self) {
         unsafe { mlirBlockDestroy(self.raw) };
     }
 }
 
-impl<'c> PartialEq for Block<'c> {
+impl PartialEq for Block<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { mlirBlockEqual(self.raw, other.raw) }
     }
 }
 
-impl<'c> Eq for Block<'c> {}
+impl Eq for Block<'_> {}
 
-impl<'c> Display for Block<'c> {
+impl Display for Block<'_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         let mut data = (formatter, Ok(()));
 
@@ -253,7 +253,7 @@ impl<'c> Display for Block<'c> {
     }
 }
 
-impl<'c> Debug for Block<'c> {
+impl Debug for Block<'_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         writeln!(formatter, "Block(")?;
         Display::fmt(self, formatter)?;
@@ -268,7 +268,7 @@ pub struct BlockRef<'c, 'a> {
     _reference: PhantomData<&'a Block<'c>>,
 }
 
-impl<'c, 'a> BlockRef<'c, 'a> {
+impl BlockRef<'_, '_> {
     /// Creates a block reference from a raw object.
     ///
     /// # Safety
@@ -295,7 +295,7 @@ impl<'c, 'a> BlockRef<'c, 'a> {
     }
 }
 
-impl<'c, 'a> Deref for BlockRef<'c, 'a> {
+impl<'a> Deref for BlockRef<'_, 'a> {
     type Target = Block<'a>;
 
     fn deref(&self) -> &Self::Target {
@@ -303,21 +303,21 @@ impl<'c, 'a> Deref for BlockRef<'c, 'a> {
     }
 }
 
-impl<'c, 'a> PartialEq for BlockRef<'c, 'a> {
+impl PartialEq for BlockRef<'_, '_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { mlirBlockEqual(self.raw, other.raw) }
     }
 }
 
-impl<'c, 'a> Eq for BlockRef<'c, 'a> {}
+impl Eq for BlockRef<'_, '_> {}
 
-impl<'c, 'a> Display for BlockRef<'c, 'a> {
+impl Display for BlockRef<'_, '_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         Display::fmt(self.deref(), formatter)
     }
 }
 
-impl<'c, 'a> Debug for BlockRef<'c, 'a> {
+impl Debug for BlockRef<'_, '_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         Debug::fmt(self.deref(), formatter)
     }

--- a/melior/src/ir/block/argument.rs
+++ b/melior/src/ir/block/argument.rs
@@ -14,7 +14,7 @@ pub struct BlockArgument<'c, 'a> {
     value: Value<'c, 'a>,
 }
 
-impl<'c, 'a> BlockArgument<'c, 'a> {
+impl<'c> BlockArgument<'c, '_> {
     /// Returns an argument number.
     pub fn argument_number(&self) -> usize {
         unsafe { mlirBlockArgumentGetArgNumber(self.value.to_raw()) as usize }
@@ -42,13 +42,13 @@ impl<'c, 'a> BlockArgument<'c, 'a> {
     }
 }
 
-impl<'c, 'a> ValueLike<'c> for BlockArgument<'c, 'a> {
+impl<'c> ValueLike<'c> for BlockArgument<'c, '_> {
     fn to_raw(&self) -> MlirValue {
         self.value.to_raw()
     }
 }
 
-impl<'c, 'a> Display for BlockArgument<'c, 'a> {
+impl Display for BlockArgument<'_, '_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         Value::from(*self).fmt(formatter)
     }

--- a/melior/src/ir/identifier.rs
+++ b/melior/src/ir/identifier.rs
@@ -54,13 +54,13 @@ impl<'c> Identifier<'c> {
     }
 }
 
-impl<'c> PartialEq for Identifier<'c> {
+impl PartialEq for Identifier<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { mlirIdentifierEqual(self.raw, other.raw) }
     }
 }
 
-impl<'c> Eq for Identifier<'c> {}
+impl Eq for Identifier<'_> {}
 
 #[cfg(test)]
 mod tests {

--- a/melior/src/ir/location.rs
+++ b/melior/src/ir/location.rs
@@ -91,13 +91,13 @@ impl<'c> Location<'c> {
     }
 }
 
-impl<'c> PartialEq for Location<'c> {
+impl PartialEq for Location<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { mlirLocationEqual(self.raw, other.raw) }
     }
 }
 
-impl<'c> Display for Location<'c> {
+impl Display for Location<'_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         let mut data = (formatter, Ok(()));
 

--- a/melior/src/ir/module.rs
+++ b/melior/src/ir/module.rs
@@ -88,7 +88,7 @@ impl<'c> Module<'c> {
     }
 }
 
-impl<'c> Drop for Module<'c> {
+impl Drop for Module<'_> {
     fn drop(&mut self) {
         unsafe { mlirModuleDestroy(self.raw) };
     }

--- a/melior/src/ir/operation.rs
+++ b/melior/src/ir/operation.rs
@@ -197,7 +197,7 @@ impl<'c> Operation<'c> {
                 StringRef::new(name).to_raw(),
             ))
         }
-        .ok_or(Error::AttributeNotFound(name.into()))
+        .ok_or_else(|| Error::AttributeNotFound(name.into()))
     }
 
     /// Checks if the operation has a attribute with the given name.
@@ -220,7 +220,7 @@ impl<'c> Operation<'c> {
     pub fn remove_attribute(&mut self, name: &str) -> Result<(), Error> {
         unsafe { mlirOperationRemoveAttributeByName(self.raw, StringRef::new(name).to_raw()) }
             .then_some(())
-            .ok_or(Error::AttributeNotFound(name.into()))
+            .ok_or_else(|| Error::AttributeNotFound(name.into()))
     }
 
     /// Returns a reference to the next operation in the same block.
@@ -302,7 +302,7 @@ impl<'c> Operation<'c> {
     }
 
     /// Converts an operation into a raw object.
-    pub fn into_raw(self) -> MlirOperation {
+    pub const fn into_raw(self) -> MlirOperation {
         let operation = self.raw;
 
         forget(self);

--- a/melior/src/ir/operation.rs
+++ b/melior/src/ir/operation.rs
@@ -311,27 +311,27 @@ impl<'c> Operation<'c> {
     }
 }
 
-impl<'c> Clone for Operation<'c> {
+impl Clone for Operation<'_> {
     fn clone(&self) -> Self {
         unsafe { Self::from_raw(mlirOperationClone(self.raw)) }
     }
 }
 
-impl<'c> Drop for Operation<'c> {
+impl Drop for Operation<'_> {
     fn drop(&mut self) {
         unsafe { mlirOperationDestroy(self.raw) };
     }
 }
 
-impl<'c> PartialEq for Operation<'c> {
+impl PartialEq for Operation<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { mlirOperationEqual(self.raw, other.raw) }
     }
 }
 
-impl<'c> Eq for Operation<'c> {}
+impl Eq for Operation<'_> {}
 
-impl<'c> Display for Operation<'c> {
+impl Display for Operation<'_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         let mut data = (formatter, Ok(()));
 
@@ -347,7 +347,7 @@ impl<'c> Display for Operation<'c> {
     }
 }
 
-impl<'c> Debug for Operation<'c> {
+impl Debug for Operation<'_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         writeln!(formatter, "Operation(")?;
         Display::fmt(self, formatter)?;
@@ -415,7 +415,7 @@ impl<'c, 'a> OperationRef<'c, 'a> {
     }
 }
 
-impl<'c, 'a> Deref for OperationRef<'c, 'a> {
+impl<'c> Deref for OperationRef<'c, '_> {
     type Target = Operation<'c>;
 
     fn deref(&self) -> &Self::Target {
@@ -423,21 +423,21 @@ impl<'c, 'a> Deref for OperationRef<'c, 'a> {
     }
 }
 
-impl<'c, 'a> PartialEq for OperationRef<'c, 'a> {
+impl PartialEq for OperationRef<'_, '_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { mlirOperationEqual(self.raw, other.raw) }
     }
 }
 
-impl<'c, 'a> Eq for OperationRef<'c, 'a> {}
+impl Eq for OperationRef<'_, '_> {}
 
-impl<'c, 'a> Display for OperationRef<'c, 'a> {
+impl Display for OperationRef<'_, '_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         Display::fmt(self.deref(), formatter)
     }
 }
 
-impl<'c, 'a> Debug for OperationRef<'c, 'a> {
+impl Debug for OperationRef<'_, '_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         Debug::fmt(self.deref(), formatter)
     }
@@ -450,7 +450,7 @@ pub struct OperationRefMut<'c, 'a> {
     _reference: PhantomData<&'a Operation<'c>>,
 }
 
-impl<'c, 'a> OperationRefMut<'c, 'a> {
+impl OperationRefMut<'_, '_> {
     /// Converts an operation reference into a raw object.
     pub const fn to_raw(self) -> MlirOperation {
         self.raw
@@ -482,7 +482,7 @@ impl<'c, 'a> OperationRefMut<'c, 'a> {
     }
 }
 
-impl<'c, 'a> Deref for OperationRefMut<'c, 'a> {
+impl<'c> Deref for OperationRefMut<'c, '_> {
     type Target = Operation<'c>;
 
     fn deref(&self) -> &Self::Target {
@@ -490,27 +490,27 @@ impl<'c, 'a> Deref for OperationRefMut<'c, 'a> {
     }
 }
 
-impl<'c, 'a> DerefMut for OperationRefMut<'c, 'a> {
+impl DerefMut for OperationRefMut<'_, '_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { transmute(self) }
     }
 }
 
-impl<'c, 'a> PartialEq for OperationRefMut<'c, 'a> {
+impl PartialEq for OperationRefMut<'_, '_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { mlirOperationEqual(self.raw, other.raw) }
     }
 }
 
-impl<'c, 'a> Eq for OperationRefMut<'c, 'a> {}
+impl Eq for OperationRefMut<'_, '_> {}
 
-impl<'c, 'a> Display for OperationRefMut<'c, 'a> {
+impl Display for OperationRefMut<'_, '_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         Display::fmt(self.deref(), formatter)
     }
 }
 
-impl<'c, 'a> Debug for OperationRefMut<'c, 'a> {
+impl Debug for OperationRefMut<'_, '_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         Debug::fmt(self.deref(), formatter)
     }

--- a/melior/src/ir/operation/builder.rs
+++ b/melior/src/ir/operation/builder.rs
@@ -75,7 +75,7 @@ impl<'c> OperationBuilder<'c> {
     /// Adds regions in a [`Vec`](std::vec::Vec).
     pub fn add_regions_vec(mut self, regions: Vec<Region<'c>>) -> Self {
         unsafe {
-            // This may fire with -D clippy::nusery, however, it is
+            // This may fire with -D clippy::nursery, however, it is
             // guaranteed by the std that ManuallyDrop<T> has the same layout as T
             #[allow(clippy::transmute_undefined_repr)]
             mlirOperationStateAddOwnedRegions(

--- a/melior/src/ir/operation/builder.rs
+++ b/melior/src/ir/operation/builder.rs
@@ -75,6 +75,9 @@ impl<'c> OperationBuilder<'c> {
     /// Adds regions in a [`Vec`](std::vec::Vec).
     pub fn add_regions_vec(mut self, regions: Vec<Region<'c>>) -> Self {
         unsafe {
+            // This may fire with -D clippy::nusery, however, it is
+            // guaranteed by the std that ManuallyDrop<T> has the same layout as T
+            #[allow(clippy::transmute_undefined_repr)]
             mlirOperationStateAddOwnedRegions(
                 &mut self.raw,
                 regions.len() as isize,

--- a/melior/src/ir/operation/result.rs
+++ b/melior/src/ir/operation/result.rs
@@ -11,7 +11,7 @@ pub struct OperationResult<'c, 'a> {
     value: Value<'c, 'a>,
 }
 
-impl<'c, 'a> OperationResult<'c, 'a> {
+impl<'c> OperationResult<'c, '_> {
     /// Returns a result number.
     pub fn result_number(&self) -> usize {
         unsafe { mlirOpResultGetResultNumber(self.value.to_raw()) as usize }
@@ -34,13 +34,13 @@ impl<'c, 'a> OperationResult<'c, 'a> {
     }
 }
 
-impl<'c, 'a> ValueLike<'c> for OperationResult<'c, 'a> {
+impl<'c> ValueLike<'c> for OperationResult<'c, '_> {
     fn to_raw(&self) -> MlirValue {
         self.value.to_raw()
     }
 }
 
-impl<'c, 'a> Display for OperationResult<'c, 'a> {
+impl Display for OperationResult<'_, '_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         Value::from(*self).fmt(formatter)
     }

--- a/melior/src/ir/region.rs
+++ b/melior/src/ir/region.rs
@@ -73,7 +73,7 @@ impl<'c> Region<'c> {
     }
 
     /// Converts a region into a raw object.
-    pub fn into_raw(self) -> mlir_sys::MlirRegion {
+    pub const fn into_raw(self) -> mlir_sys::MlirRegion {
         let region = self.raw;
 
         forget(self);

--- a/melior/src/ir/region.rs
+++ b/melior/src/ir/region.rs
@@ -82,25 +82,25 @@ impl<'c> Region<'c> {
     }
 }
 
-impl<'c> Default for Region<'c> {
+impl Default for Region<'_> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'c> Drop for Region<'c> {
+impl Drop for Region<'_> {
     fn drop(&mut self) {
         unsafe { mlirRegionDestroy(self.raw) }
     }
 }
 
-impl<'c> PartialEq for Region<'c> {
+impl PartialEq for Region<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { mlirRegionEqual(self.raw, other.raw) }
     }
 }
 
-impl<'c> Eq for Region<'c> {}
+impl Eq for Region<'_> {}
 
 /// A reference to a region.
 #[derive(Clone, Copy, Debug)]
@@ -109,7 +109,7 @@ pub struct RegionRef<'c, 'a> {
     _region: PhantomData<&'a Region<'c>>,
 }
 
-impl<'c, 'a> RegionRef<'c, 'a> {
+impl RegionRef<'_, '_> {
     /// Creates a region from a raw object.
     ///
     /// # Safety
@@ -136,7 +136,7 @@ impl<'c, 'a> RegionRef<'c, 'a> {
     }
 }
 
-impl<'c, 'a> Deref for RegionRef<'c, 'a> {
+impl<'c> Deref for RegionRef<'c, '_> {
     type Target = Region<'c>;
 
     fn deref(&self) -> &Self::Target {
@@ -144,13 +144,13 @@ impl<'c, 'a> Deref for RegionRef<'c, 'a> {
     }
 }
 
-impl<'c, 'a> PartialEq for RegionRef<'c, 'a> {
+impl PartialEq for RegionRef<'_, '_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { mlirRegionEqual(self.raw, other.raw) }
     }
 }
 
-impl<'c, 'a> Eq for RegionRef<'c, 'a> {}
+impl Eq for RegionRef<'_, '_> {}
 
 #[cfg(test)]
 mod tests {

--- a/melior/src/ir/type.rs
+++ b/melior/src/ir/type.rs
@@ -137,15 +137,15 @@ impl<'c> TypeLike<'c> for Type<'c> {
     }
 }
 
-impl<'c> PartialEq for Type<'c> {
+impl PartialEq for Type<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { mlirTypeEqual(self.raw, other.raw) }
     }
 }
 
-impl<'c> Eq for Type<'c> {}
+impl Eq for Type<'_> {}
 
-impl<'c> Display for Type<'c> {
+impl Display for Type<'_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         let mut data = (formatter, Ok(()));
 
@@ -161,7 +161,7 @@ impl<'c> Display for Type<'c> {
     }
 }
 
-impl<'c> Debug for Type<'c> {
+impl Debug for Type<'_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         write!(formatter, "Type(")?;
         Display::fmt(self, formatter)?;

--- a/melior/src/ir/value.rs
+++ b/melior/src/ir/value.rs
@@ -20,7 +20,7 @@ pub struct Value<'c, 'a> {
     _parent: PhantomData<&'a ()>,
 }
 
-impl<'c, 'a> Value<'c, 'a> {
+impl Value<'_, '_> {
     /// Creates a value from a raw object.
     ///
     /// # Safety
@@ -35,21 +35,21 @@ impl<'c, 'a> Value<'c, 'a> {
     }
 }
 
-impl<'c, 'a> ValueLike<'c> for Value<'c, 'a> {
+impl<'c> ValueLike<'c> for Value<'c, '_> {
     fn to_raw(&self) -> MlirValue {
         self.raw
     }
 }
 
-impl<'c, 'a> PartialEq for Value<'c, 'a> {
+impl PartialEq for Value<'_, '_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { mlirValueEqual(self.raw, other.raw) }
     }
 }
 
-impl<'c, 'a> Eq for Value<'c, 'a> {}
+impl Eq for Value<'_, '_> {}
 
-impl<'c, 'a> Display for Value<'c, 'a> {
+impl Display for Value<'_, '_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         let mut data = (formatter, Ok(()));
 
@@ -65,7 +65,7 @@ impl<'c, 'a> Display for Value<'c, 'a> {
     }
 }
 
-impl<'c, 'a> Debug for Value<'c, 'a> {
+impl Debug for Value<'_, '_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         writeln!(formatter, "Value(")?;
         Display::fmt(self, formatter)?;

--- a/melior/src/pass/external.rs
+++ b/melior/src/pass/external.rs
@@ -18,7 +18,7 @@ pub struct ExternalPass<'a> {
     _reference: PhantomData<&'a MlirExternalPass>,
 }
 
-impl<'a> ExternalPass<'a> {
+impl ExternalPass<'_> {
     /// Signals that the pass has failed.
     pub fn signal_failure(self) {
         unsafe { mlirExternalPassSignalFailure(self.raw) }
@@ -291,7 +291,7 @@ mod tests {
             }
         }
 
-        impl<'c> TestPass<'c> {
+        impl TestPass<'_> {
             fn into_pass(self) -> Pass {
                 create_external(
                     self,

--- a/melior/src/pass/external.rs
+++ b/melior/src/pass/external.rs
@@ -25,7 +25,7 @@ impl ExternalPass<'_> {
     }
 
     /// Converts an external pass to a raw object.
-    pub fn to_raw(self) -> MlirExternalPass {
+    pub const fn to_raw(self) -> MlirExternalPass {
         self.raw
     }
 
@@ -183,7 +183,7 @@ pub fn create_external<'c, T: RunExternalPass<'c>>(
             StringRef::new(description).to_raw(),
             StringRef::new(op_name).to_raw(),
             dependent_dialects.len() as isize,
-            dependent_dialects.as_ptr() as _,
+            dependent_dialects.as_ptr().cast_mut() as _,
             MlirExternalPassCallbacks {
                 construct: Some(transmute::<*const (), unsafe extern "C" fn(*mut c_void)>(
                     callback_construct::<T> as *const (),

--- a/melior/src/pass/manager.rs
+++ b/melior/src/pass/manager.rs
@@ -17,7 +17,7 @@ pub struct PassManager<'c> {
     _context: PhantomData<&'c Context>,
 }
 
-impl<'c> PassManager<'c> {
+impl PassManager<'_> {
     /// Creates a pass manager.
     pub fn new(context: &Context) -> Self {
         Self {
@@ -70,7 +70,7 @@ impl<'c> PassManager<'c> {
     }
 }
 
-impl<'c> Drop for PassManager<'c> {
+impl Drop for PassManager<'_> {
     fn drop(&mut self) {
         unsafe { mlirPassManagerDestroy(self.raw) }
     }

--- a/melior/src/pass/operation_manager.rs
+++ b/melior/src/pass/operation_manager.rs
@@ -17,7 +17,7 @@ pub struct OperationPassManager<'c, 'a> {
     _parent: PhantomData<&'a PassManager<'c>>,
 }
 
-impl<'c, 'a> OperationPassManager<'c, 'a> {
+impl OperationPassManager<'_, '_> {
     /// Returns an operation pass manager for nested operations corresponding to
     /// a given name.
     pub fn nested_under(&self, name: &str) -> Self {
@@ -49,7 +49,7 @@ impl<'c, 'a> OperationPassManager<'c, 'a> {
     }
 }
 
-impl<'c, 'a> Display for OperationPassManager<'c, 'a> {
+impl Display for OperationPassManager<'_, '_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         let mut data = (formatter, Ok(()));
 

--- a/melior/src/string_ref.rs
+++ b/melior/src/string_ref.rs
@@ -65,13 +65,13 @@ impl<'a> StringRef<'a> {
     }
 }
 
-impl<'a> PartialEq for StringRef<'a> {
+impl PartialEq for StringRef<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { mlirStringRefEqual(self.raw, other.raw) }
     }
 }
 
-impl<'a> Eq for StringRef<'a> {}
+impl Eq for StringRef<'_> {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Should fix the new lint ci errors due to rust 1.83.0 new clippy lints

On rust 1.83.0 with clippy `cargo clippy -- -D clippy::nursery -A clippy::use_self`

There are some more places where i could add const (in mut self places) but thats from 1.83.0 itself and i dont know if you are ok with setting the MSRV to it, so i didnt add those.